### PR TITLE
Netmap and portscan displays delay time

### DIFF
--- a/src/arg_parser/mod.rs
+++ b/src/arg_parser/mod.rs
@@ -1,2 +1,5 @@
+pub mod netmap_parser;
+pub use netmap_parser::NetMapArgs;
+
 pub mod pscan_parser;
 pub use pscan_parser::PortScanArgs;

--- a/src/arg_parser/netmap_parser.rs
+++ b/src/arg_parser/netmap_parser.rs
@@ -1,0 +1,20 @@
+pub use clap::Parser;
+
+
+
+#[derive(Parser)]
+#[command(name = "netmap", about = "Network Mapper")]
+pub struct NetMapArgs {
+
+    /// Send packets to hosts in random order
+    #[arg(short, long)]
+    pub random: bool,
+
+
+    /// Add a delay between packet transmissions.
+    ///
+    /// Examples: 0.5 or 1-2 (seconds).
+    #[arg(short, long)]
+    pub delay: Option<String>,
+
+}

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -57,21 +57,21 @@ impl PortScanner {
     fn send_probes(&self, pkt_builder: &PacketBuilder, pkt_sender: &mut PacketSender) {
         let (ip, ports, delays) = self.get_data_for_loop();
 
-        for (port, delay) in ports.zip(delays) {
-            let tcp_packet = pkt_builder.build_tcp_packet(self.args.target_ip, port);
+        for (port, delay) in ports.iter().zip(delays.iter())  {
+            let tcp_packet = pkt_builder.build_tcp_packet(self.args.target_ip, *port);
             pkt_sender.send_tcp(tcp_packet, self.args.target_ip);
             
-            display_progress(format!("Packet sent to port: {:<5} - {:<15}", port, ip));
-            thread::sleep(Duration::from_secs_f32(delay));
+            display_progress(format!("Packet sent to {} port {:<5} - delay {:.2}", ip, port, delay));
+            thread::sleep(Duration::from_secs_f32(*delay));
         }
     }
 
 
 
-    fn get_data_for_loop(&self) -> (String, Vec<u32>, Vec<f32>) {
+    fn get_data_for_loop(&self) -> (String, Vec<u16>, Vec<f32>) {
         let ip     = self.args.target_ip.to_string();
         let ports  = PortGenerator::get_ports(self.args.ports.clone(), self.args.random.clone());
-        let delays = DelayTimeGenerator::get_delay_list(self.args.delay.clone(), ports.len())
+        let delays = DelayTimeGenerator::get_delay_list(self.args.delay.clone(), ports.len());
         (ip, ports, delays)
     }
 

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -2,7 +2,7 @@ use std::{thread, time::Duration};
 use clap::Parser;
 use crate::arg_parser::PortScanArgs;
 use crate::packets::{PacketBuilder, PacketDissector, PacketSender, PacketSniffer};
-use crate::utils::{PortGenerator, display_progress, get_host_name};
+use crate::utils::{PortGenerator, display_progress, get_host_name, DelayTimeGenerator};
 
 
 
@@ -55,16 +55,24 @@ impl PortScanner {
 
 
     fn send_probes(&self, pkt_builder: &PacketBuilder, pkt_sender: &mut PacketSender) {
-        let ip    = self.args.target_ip.to_string();
-        let ports = PortGenerator::get_ports(self.args.ports.clone(), self.args.random.clone()); 
+        let (ip, ports, delays) = self.get_data_for_loop();
 
-        for port in ports {
+        for (port, delay) in ports.zip(delays) {
             let tcp_packet = pkt_builder.build_tcp_packet(self.args.target_ip, port);
             pkt_sender.send_tcp(tcp_packet, self.args.target_ip);
             
             display_progress(format!("Packet sent to port: {:<5} - {:<15}", port, ip));
-            thread::sleep(Duration::from_secs_f32(0.02));
+            thread::sleep(Duration::from_secs_f32(delay));
         }
+    }
+
+
+
+    fn get_data_for_loop(&self) -> (String, Vec<u32>, Vec<f32>) {
+        let ip     = self.args.target_ip.to_string();
+        let ports  = PortGenerator::get_ports(self.args.ports.clone(), self.args.random.clone());
+        let delays = DelayTimeGenerator::get_delay_list(self.args.delay.clone(), ports.len())
+        (ip, ports, delays)
     }
 
 

--- a/src/packets/pkt_builder.rs
+++ b/src/packets/pkt_builder.rs
@@ -1,11 +1,9 @@
 use std::net::Ipv4Addr;
 use rand::Rng;
-use pnet::{
-    packet::{
-        ip::{IpNextHeaderProtocols, IpNextHeaderProtocol},
-        ipv4::{MutableIpv4Packet, checksum as ip_checksum},
-        tcp::{MutableTcpPacket, TcpFlags, ipv4_checksum as tcp_checksum},
-    }
+use pnet::packet::{
+    ip::{IpNextHeaderProtocols, IpNextHeaderProtocol},
+    ipv4::{MutableIpv4Packet, checksum as ip_checksum},
+    tcp::{MutableTcpPacket, TcpFlags, ipv4_checksum as tcp_checksum},
 };
 use crate::utils::get_default_iface_ip;
 

--- a/src/utils/delay_generator.rs
+++ b/src/utils/delay_generator.rs
@@ -6,7 +6,7 @@ pub struct DelayTimeGenerator;
 
 impl DelayTimeGenerator {
 
-    pub fn get_delay_list(delay_arg: Option<String>, quantity: u64) -> Vec<f32> {
+    pub fn get_delay_list(delay_arg: Option<String>, quantity: usize) -> Vec<f32> {
         if delay_arg.is_none() {
             return Self::fixed_delay_range("0.02".to_string(), quantity)
         }
@@ -22,7 +22,7 @@ impl DelayTimeGenerator {
 
 
 
-    fn fixed_delay_range(value_str: String, quantity: u64) -> Vec<f32> {
+    fn fixed_delay_range(value_str: String, quantity: usize) -> Vec<f32> {
         let value            = Self::validate_number(&value_str);
         let vector: Vec<f32> = vec![value; quantity];
         vector
@@ -30,7 +30,7 @@ impl DelayTimeGenerator {
 
 
 
-    fn random_delay_range(range_str: String, quantity: u64) -> Vec<f32> {
+    fn random_delay_range(range_str: String, quantity: usize) -> Vec<f32> {
         let parts: Vec<&str> = range_str.split("-").collect();
         let min              = Self::validate_number(&parts[0]);
         let max              = Self::validate_number(&parts[1]);
@@ -50,7 +50,7 @@ impl DelayTimeGenerator {
 
 
     fn validate_number(number_str: &str) -> f32 {        
-        let number32: f32 = texto.parse().unwrap_or_else(|_| {
+        let number32: f32 = number_str.parse().unwrap_or_else(|_| {
             display_error_and_exit(format!("Invalid number: {}", number_str));
         });
         number32

--- a/src/utils/delay_generator.rs
+++ b/src/utils/delay_generator.rs
@@ -22,18 +22,18 @@ impl DelayTimeGenerator {
 
 
 
-    fn fixed_delay_range(number_str: String, quantity: u64) {
-        let value            = Self::validate_number(value_str);
+    fn fixed_delay_range(value_str: String, quantity: u64) -> Vec<f32> {
+        let value            = Self::validate_number(&value_str);
         let vector: Vec<f32> = vec![value; quantity];
         vector
     }
 
 
 
-    fn random_delay_range(range_str: String, quantity: u64) Vec<f32> {
-        let parts: Vec<&str> = port_range.split("-").collect();
-        let min              = Self::validate_number(parts[0]);
-        let max              = Self::validate_number(parts[1]);
+    fn random_delay_range(range_str: String, quantity: u64) -> Vec<f32> {
+        let parts: Vec<&str> = range_str.split("-").collect();
+        let min              = Self::validate_number(&parts[0]);
+        let max              = Self::validate_number(&parts[1]);
 
         if min >= max || parts.len() > 2 {
             display_error_and_exit(format!("Invalid range: {}", range_str));
@@ -49,7 +49,7 @@ impl DelayTimeGenerator {
 
 
 
-    fn validate_number(number_str: String) -> f32 {        
+    fn validate_number(number_str: &str) -> f32 {        
         let number32: f32 = texto.parse().unwrap_or_else(|_| {
             display_error_and_exit(format!("Invalid number: {}", number_str));
         });

--- a/src/utils/delay_generator.rs
+++ b/src/utils/delay_generator.rs
@@ -1,0 +1,60 @@
+use rand::Rng;
+use crate::utils::display_error_and_exit;
+
+
+pub struct DelayTimeGenerator;
+
+impl DelayTimeGenerator {
+
+    pub fn get_delay_list(delay_arg: Option<String>, quantity: u64) -> Vec<f32> {
+        if delay_arg.is_none() {
+            return Self::fixed_delay_range("0.02".to_string(), quantity)
+        }
+
+        let delay_str = delay_arg.unwrap();
+
+        if delay_str.contains("-") {
+            return Self::random_delay_range(delay_str, quantity)
+        }
+
+        Self::fixed_delay_range(delay_str, quantity)
+    }
+
+
+
+    fn fixed_delay_range(number_str: String, quantity: u64) {
+        let value            = Self::validate_number(value_str);
+        let vector: Vec<f32> = vec![value; quantity];
+        vector
+    }
+
+
+
+    fn random_delay_range(range_str: String, quantity: u64) Vec<f32> {
+        let parts: Vec<&str> = port_range.split("-").collect();
+        let min              = Self::validate_number(parts[0]);
+        let max              = Self::validate_number(parts[1]);
+
+        if min >= max || parts.len() > 2 {
+            display_error_and_exit(format!("Invalid range: {}", range_str));
+        };
+
+        let mut rng          = rand::thread_rng();
+        let vector: Vec<f32> = (0..quantity)
+            .map(|_| rng.gen_range(min..=max))
+            .collect();
+
+        vector
+    }
+
+
+
+    fn validate_number(number_str: String) -> f32 {        
+        let number32: f32 = texto.parse().unwrap_or_else(|_| {
+            display_error_and_exit(format!("Invalid number: {}", number_str));
+        });
+        number32
+    }
+
+
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,6 @@
+pub mod delay_generator;
+pub use DelayTimeGenerator;
+
 pub mod displays;
 pub use displays::{display_error_and_exit, display_progress};
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,5 @@
 pub mod delay_generator;
-pub use DelayTimeGenerator;
+pub use delay_generator::DelayTimeGenerator;
 
 pub mod displays;
 pub use displays::{display_error_and_exit, display_progress};


### PR DESCRIPTION
This pull request adds support for a user-defined delay time. An implementation block was added to create a vector with a specified number of values. The port scanner and network mapper were refactored to use and display the delay time list. Additionally, an argument parser was added to the network mapper to handle command-line arguments.