### PR TITLE
Netmap can use portscan

### DIFF
--- a/src/arg_parser/netmap_parser.rs
+++ b/src/arg_parser/netmap_parser.rs
@@ -17,4 +17,9 @@ pub struct NetMapArgs {
     #[arg(short, long)]
     pub delay: Option<String>,
 
+
+    /// Scan ports on active hosts
+    #[arg(short = 'P', long = "Portscan")]
+    pub portscan: bool,
+
 }

--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -150,7 +150,7 @@ impl NetworkMapper {
 
 
     fn display_header() {
-        println!("{}", format!("\n{:<15}  {:<17}  {}", "IP Address", "MAC Address", "Hostname"));
+        println!("\n{}", format!("\n{:<15}  {:<17}  {}", "IP Address", "MAC Address", "Hostname"));
         println!("{}", format!("{}  {}  {}", "-".repeat(15), "-".repeat(17), "-".repeat(8)));
     }
 

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -22,6 +22,7 @@ impl PortScanner {
             return_data,
             raw_packets: Vec::new(),
             open_ports: Vec::new(),
+
         }
     }
 
@@ -68,6 +69,7 @@ impl PortScanner {
             display_progress(format!("Packet sent to {} port {:<5} - delay: {:.2}", ip, port, delay));
             thread::sleep(Duration::from_secs_f32(*delay));
         }
+        println!("");
     }
 
 
@@ -100,11 +102,10 @@ impl PortScanner {
 
     fn display_result(&self) {
         let device_name = get_host_name(&self.args.target_ip.to_string());
+        let ports       = self.open_ports.join(", ");
 
         println!("\nOpen ports from {} ({})", device_name, self.args.target_ip);
-        for port in &self.open_ports{
-            println!(" -> {}", port);
-        }
+        println!("{}", ports);
     }
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ impl Command {
     fn execute_function(&mut self) {
         match self.command.as_str() {
             "pscan" => {
-                let mut scanner = PortScanner::new(self.arguments.clone());
+                let mut scanner = PortScanner::new(self.arguments.clone(), false);
                 scanner.execute();
             }
             "netmap" => {

--- a/src/utils/delay_generator.rs
+++ b/src/utils/delay_generator.rs
@@ -56,5 +56,4 @@ impl DelayTimeGenerator {
         number32
     }
 
-
 }


### PR DESCRIPTION
This pull request introduces a new flag in the network mapper, allowing NetMap to use PortScan to scan all active IPs. The PortScan implementation block was refactored to return data when needed, and the NetMap display was updated to show ports dynamically.