### PR TITLE
Added Packet flooder

### DIFF
--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -2,7 +2,7 @@ use std::net::Ipv4Addr;
 use ipnet::Ipv4Net;
 use rand::{Rng, rngs::ThreadRng};
 use crate::pkt_kit::{PacketBuilder, PacketSender};
-use crate::utils::{default_ipv4_net, default_iface_mac};
+use crate::utils::{default_ipv4_net};
 
 
 

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -1,0 +1,39 @@
+use std::net::Ipv4Addr;
+use ipnet::Ipv4Net;
+use rand::{Rng, rngs::ThreadRng};
+use crate::pkt_kit::{PacketBuilder, PacketSender};
+use crate::utils::default_ipv4_net;
+
+
+
+pub struct PacketFlood {
+    net:   Ipv4Net,
+    start: u32,
+    end:   u32,
+    rng:   ThreadRng,
+}
+
+impl PacketFlood {
+
+    pub fn new() -> Self {
+        Self {
+            net:   default_ipv4_net(),
+            start: 0,
+            end:   0,
+            rng:   rand::thread_rng(),
+        }
+    }
+
+
+
+    pub fn execute(&mut self){
+        self.start = self.net.network().into();
+        self.end = self.net.broadcast().into();
+        while true {
+            let rand_num = self.rng.gen_range(self.start..=self.end);
+            let ip: Ipv4Addr = rand_num.into();
+            println!("{}", ip);
+        }
+    }
+
+}

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -2,7 +2,7 @@ use std::net::Ipv4Addr;
 use ipnet::Ipv4Net;
 use rand::{Rng, rngs::ThreadRng};
 use crate::pkt_kit::{PacketBuilder, PacketSender};
-use crate::utils::default_ipv4_net;
+use crate::utils::{default_ipv4_net, default_iface_mac};
 
 
 
@@ -12,6 +12,7 @@ pub struct PacketFlood {
     end:   u32,
     rng:   ThreadRng,
 }
+
 
 impl PacketFlood {
 

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -39,10 +39,21 @@ impl PacketFlood {
 
 
 
+    fn setup_tools() -> (PacketBuilder, PacketSender) {
+        let pkt_builder = PacketBuilder::new();
+        let pkt_sender  = PacketSender::new();
+        (pkt_builder, pkt_sender)
+    }
+
+
+
     fn send_endlessly(&mut self) {
+        let (mut pkt_builder, mut pkt_sender) = Self::setup_tools();
+
         while true {
-            let ip = self.get_random_ip();
-            println!("{}", ip);
+            let ip  = self.get_random_ip();
+            let pkt = pkt_builder.build_tcp_ether_packet(ip);
+            pkt_sender.send_layer2_frame(pkt);
         }
     }
 

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -1,5 +1,4 @@
 use std::net::Ipv4Addr;
-use ipnet::Ipv4Net;
 use rand::{Rng, rngs::ThreadRng};
 use crate::pkt_kit::{PacketBuilder, PacketSender};
 use crate::utils::{default_ipv4_net};
@@ -7,7 +6,6 @@ use crate::utils::{default_ipv4_net};
 
 
 pub struct PacketFlood {
-    net:   Ipv4Net,
     start: u32,
     end:   u32,
     rng:   ThreadRng,
@@ -18,7 +16,6 @@ impl PacketFlood {
 
     pub fn new() -> Self {
         Self {
-            net:   default_ipv4_net(),
             start: 0,
             end:   0,
             rng:   rand::thread_rng(),
@@ -28,13 +25,33 @@ impl PacketFlood {
 
 
     pub fn execute(&mut self){
-        self.start = self.net.network().into();
-        self.end = self.net.broadcast().into();
+        self.set_ip_range();
+        self.send_endlessly();
+    }
+
+
+
+    fn set_ip_range(&mut self) {
+        let net    = default_ipv4_net();
+        self.start = net.network().into();
+        self.end   = net.broadcast().into();
+    }
+
+
+
+    fn send_endlessly(&mut self) {
         while true {
-            let rand_num = self.rng.gen_range(self.start..=self.end);
-            let ip: Ipv4Addr = rand_num.into();
+            let ip = self.get_random_ip();
             println!("{}", ip);
         }
+    }
+
+
+
+    fn get_random_ip(&mut self) -> Ipv4Addr {
+        let rand_num     = self.rng.gen_range(self.start..=self.end);
+        let ip: Ipv4Addr = rand_num.into();
+        ip
     }
 
 }

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -1,3 +1,6 @@
+pub mod flood;
+pub use flood::PacketFlood;
+
 pub mod netmap;
 pub use netmap::NetworkMapper;
 

--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -44,7 +44,7 @@ impl NetworkMapper {
 
 
     fn setup_tools() -> (PacketBuilder, PacketSender, PacketSniffer) {
-        let pkt_builder     = PacketBuilder::new("layer2".to_string());
+        let pkt_builder     = PacketBuilder::new();
         let pkt_sender      = PacketSender::new();
         let mut pkt_sniffer = PacketSniffer::new("netmap".to_string(), "".to_string());
 

--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -58,8 +58,8 @@ impl NetworkMapper {
         let (ip_range, total, delays) = self.get_data_for_loop();
 
         for (i, (ip, delay)) in ip_range.into_iter().zip(delays.iter()).enumerate() {
-            let tcp_packet = pkt_builder.build_tcp_packet(ip, 80);
-            pkt_sender.send_tcp(tcp_packet, ip);
+            let tcp_packet = pkt_builder.build_tcp_ip_packet(ip, 80);
+            pkt_sender.send_layer3_tcp(tcp_packet, ip);
             
             let msg = format!("Packets sent: {}/{} - {:<15} - delay: {:.2}", i+1, total, ip.to_string(), delay);
             display_progress(msg);

--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -4,7 +4,7 @@ use ipnet::Ipv4AddrRange;
 use crate::arg_parser::{NetMapArgs, PortScanArgs};
 use crate::engines::PortScanner;
 use crate::pkt_kit::{PacketBuilder, PacketDissector, PacketSender, PacketSniffer};
-use crate::utils::{display_progress, default_ipv4_net, get_host_name, DelayTimeGenerator};
+use crate::utils::{inline_display, default_ipv4_net, get_host_name, DelayTimeGenerator};
 
 
 
@@ -61,8 +61,7 @@ impl NetworkMapper {
             let tcp_packet = pkt_builder.build_tcp_ip_packet(ip, 80);
             pkt_sender.send_layer3_tcp(tcp_packet, ip);
             
-            let msg = format!("Packets sent: {}/{} - {:<15} - delay: {:.2}", i+1, total, ip.to_string(), delay);
-            display_progress(msg);
+            Self::display_progress(i+1, total, ip.to_string(), *delay);
             thread::sleep(Duration::from_secs_f32(*delay));
         }
         println!("");
@@ -81,6 +80,13 @@ impl NetworkMapper {
 
     fn get_ip_range() -> Ipv4AddrRange {
         default_ipv4_net().hosts()
+    }
+
+
+
+    fn display_progress(i: usize, total: usize, ip: String, delay: f32) {
+        let msg = format!("Packets sent: {}/{} - {:<15} - delay: {:.2}", i, total, ip, delay);
+        inline_display(msg);
     }
 
 

--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -44,7 +44,7 @@ impl NetworkMapper {
 
 
     fn setup_tools() -> (PacketBuilder, PacketSender, PacketSniffer) {
-        let pkt_builder     = PacketBuilder::new();
+        let pkt_builder     = PacketBuilder::new("layer2".to_string());
         let pkt_sender      = PacketSender::new();
         let mut pkt_sniffer = PacketSniffer::new("netmap".to_string(), "".to_string());
 

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -49,7 +49,7 @@ impl PortScanner {
 
 
     fn setup_tools(&self) -> (PacketBuilder, PacketSender, PacketSniffer) {
-        let pkt_builder     = PacketBuilder::new();
+        let pkt_builder     = PacketBuilder::new("layer2".to_string());
         let pkt_sender      = PacketSender::new();
         let mut pkt_sniffer = PacketSniffer::new("pscan".to_string(), self.args.target_ip.to_string());
 

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -29,7 +29,11 @@ impl PortScanner {
     pub fn execute(&mut self) -> Vec<String> {
         self.send_and_receive();
         self.process_raw_packets();
-        if self.return_data { return self.open_ports.clone() }
+        
+        if self.return_data {
+            return self.open_ports.clone()
+        }
+        
         self.display_result();
         Vec::new()
     }

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -1,7 +1,7 @@
 use std::{thread, time::Duration};
 use crate::arg_parser::PortScanArgs;
 use crate::pkt_kit::{PacketBuilder, PacketDissector, PacketSender, PacketSniffer};
-use crate::utils::{PortGenerator, display_progress, get_host_name, DelayTimeGenerator};
+use crate::utils::{PortGenerator, inline_display, get_host_name, DelayTimeGenerator};
 
 
 
@@ -68,7 +68,7 @@ impl PortScanner {
             let tcp_packet = pkt_builder.build_tcp_ip_packet(self.args.target_ip, *port);
             pkt_sender.send_layer3_tcp(tcp_packet, self.args.target_ip);
             
-            display_progress(format!("Packet sent to {} port {:<5} - delay: {:.2}", ip, port, delay));
+            Self::display_progress(ip.clone(), *port, *delay);
             thread::sleep(Duration::from_secs_f32(*delay));
         }
         println!("");
@@ -81,6 +81,13 @@ impl PortScanner {
         let ports  = PortGenerator::get_ports(self.args.ports.clone(), self.args.random.clone());
         let delays = DelayTimeGenerator::get_delay_list(self.args.delay.clone(), ports.len());
         (ip, ports, delays)
+    }
+
+
+
+    fn display_progress(ip: String, port: u16, delay: f32) {
+        let msg = format!("Packet sent to {} port {:<5} - delay: {:.2}", ip, port, delay);
+        inline_display(msg);
     }
 
 

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -65,8 +65,8 @@ impl PortScanner {
         let (ip, ports, delays) = self.get_data_for_loop();
 
         for (port, delay) in ports.iter().zip(delays.iter())  {
-            let tcp_packet = pkt_builder.build_tcp_packet(self.args.target_ip, *port);
-            pkt_sender.send_tcp(tcp_packet, self.args.target_ip);
+            let tcp_packet = pkt_builder.build_tcp_ip_packet(self.args.target_ip, *port);
+            pkt_sender.send_layer3_tcp(tcp_packet, self.args.target_ip);
             
             display_progress(format!("Packet sent to {} port {:<5} - delay: {:.2}", ip, port, delay));
             thread::sleep(Duration::from_secs_f32(*delay));

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -49,7 +49,7 @@ impl PortScanner {
 
 
     fn setup_tools(&self) -> (PacketBuilder, PacketSender, PacketSniffer) {
-        let pkt_builder     = PacketBuilder::new("layer2".to_string());
+        let pkt_builder     = PacketBuilder::new();
         let pkt_sender      = PacketSender::new();
         let mut pkt_sniffer = PacketSniffer::new("pscan".to_string(), self.args.target_ip.to_string());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,12 +55,18 @@ impl Command {
 
     fn execute_function(&mut self) {
         match self.command.as_str() {
+            "flood"  => self.execute_flood(),
             "netmap" => self.execute_netmap(),
             "pscan"  => self.execute_portsc(),
             _        => abort(format!("No command '{}'", self.command)),
         }
     }
 
+
+    fn execute_flood(&self) {
+        let mut flood = PacketFlood::new();
+        flood.execute();
+    }
 
 
     fn execute_netmap(&self) {

--- a/src/pkt_kit/pkt_builder.rs
+++ b/src/pkt_kit/pkt_builder.rs
@@ -1,18 +1,21 @@
 use std::net::Ipv4Addr;
 use rand::{Rng, rngs::ThreadRng};
+use pnet::datalink::MacAddr;
 use pnet::packet::{
+    ethernet::{EtherTypes, MutableEthernetPacket},
     ip::{IpNextHeaderProtocols, IpNextHeaderProtocol},
     ipv4::{MutableIpv4Packet, checksum as ip_checksum},
     tcp::{MutableTcpPacket, TcpFlags, ipv4_checksum as tcp_checksum},
 };
-use crate::utils::default_ipv4_addr;
+use crate::utils::{default_ipv4_addr, default_iface_mac};
 
 
 
 pub struct PacketBuilder {
-    buffer: [u8; 40],
-    src_ip: Ipv4Addr,
-    rng:    ThreadRng,
+    buffer:  [u8; 40],
+    src_ip:  Ipv4Addr,
+    src_mac: MacAddr,
+    rng:     ThreadRng,
 }
 
 
@@ -20,19 +23,25 @@ impl PacketBuilder {
 
     pub fn new() -> Self {
         Self {
-            buffer: [0u8; 40],
-            src_ip: default_ipv4_addr(),
-            rng:    rand::thread_rng(),
+            buffer:  [0u8; 40],
+            src_ip:  default_ipv4_addr(),
+            src_mac: default_iface_mac(),
+            rng:     rand::thread_rng(),
         }
     }
 
 
 
     pub fn build_tcp_packet(&mut self, dst_ip: Ipv4Addr, dst_port: u16) -> [u8; 40] {
-        let src_port = self.rng.gen_range(10000..=65535);
+        self.add_ip_header(dst_ip, IpNextHeaderProtocols::Tcp);
+        self.add_tcp_header(dst_ip, dst_port);
+        self.buffer
+    }
 
-        self.add_ip_layer(dst_ip, IpNextHeaderProtocols::Tcp);
-        
+
+
+    fn add_tcp_header(&mut self, dst_ip: Ipv4Addr, dst_port: u16) {
+        let src_port       = self.rng.gen_range(10000..=65535);
         let mut tcp_header = MutableTcpPacket::new(&mut self.buffer[20..]).unwrap();
         tcp_header.set_source(src_port);
         tcp_header.set_destination(dst_port);
@@ -43,13 +52,11 @@ impl PacketBuilder {
 
         let pseudo_header_sum = tcp_checksum(&tcp_header.to_immutable(), &self.src_ip, &dst_ip);
         tcp_header.set_checksum(pseudo_header_sum);
-        
-        self.buffer
     }
 
 
 
-    fn add_ip_layer(&mut self, dst_ip:Ipv4Addr, protocol: IpNextHeaderProtocol) {
+    fn add_ip_header(&mut self, dst_ip:Ipv4Addr, protocol: IpNextHeaderProtocol) {
         let mut ip_header = MutableIpv4Packet::new(&mut self.buffer[..20]).unwrap();
         ip_header.set_version(4);
         ip_header.set_header_length(5);
@@ -62,5 +69,25 @@ impl PacketBuilder {
         let checksum = ip_checksum(&ip_header.to_immutable());
         ip_header.set_checksum(checksum);
     }
+
+
+
+    fn add_ether_header(&mut self) {
+        let dst_mac        = self.random_mac();
+        let mut eth_header = MutableEthernetPacket::new(&mut self.buffer[..14]).unwrap();
+        eth_header.set_source(self.src_mac);
+        eth_header.set_destination(dst_mac);
+        eth_header.set_ethertype(EtherTypes::Ipv4);
+    }
+
+
+
+    fn random_mac(&mut self) -> MacAddr {
+        let mut bytes = [0u8; 6];
+        for b in bytes.iter_mut() { *b = self.rng.r#gen(); }
+        bytes[0] = (bytes[0] | 0x02) & 0xFE;
+        MacAddr::new(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5])
+    }
+
 
 }

--- a/src/pkt_kit/pkt_builder.rs
+++ b/src/pkt_kit/pkt_builder.rs
@@ -29,7 +29,7 @@ pub struct PacketBuilder {
 
 impl PacketBuilder {
 
-    pub fn new(layer: String) -> Self {
+    pub fn new() -> Self {
         Self {
             buffers: PacketBuffer::default(),
             src_ip:  default_ipv4_addr(),
@@ -87,7 +87,7 @@ impl PacketBuilder {
         let mut ip_header = MutableIpv4Packet::new(&mut self.buffers.ip).unwrap();
         ip_header.set_version(4);
         ip_header.set_header_length(5);
-        ip_header.set_total_length(54);
+        ip_header.set_total_length(40);
         ip_header.set_ttl(64);
         ip_header.set_next_level_protocol(protocol);
         ip_header.set_source(self.src_ip);

--- a/src/pkt_kit/pkt_builder.rs
+++ b/src/pkt_kit/pkt_builder.rs
@@ -32,7 +32,13 @@ impl PacketBuilder {
 
 
 
-    pub fn build_tcp_packet(&mut self, dst_ip: Ipv4Addr, dst_port: u16) -> [u8; 40] {
+    pub fn build_tcp_ether_packet(&mut self, dst_ip: Ipv4Addr) -> [u8; 40] {
+
+    }
+
+
+
+    pub fn build_tcp_ip_packet(&mut self, dst_ip: Ipv4Addr, dst_port: u16) -> [u8; 40] {
         self.add_ip_header(dst_ip, IpNextHeaderProtocols::Tcp);
         self.add_tcp_header(dst_ip, dst_port);
         self.buffer
@@ -88,6 +94,5 @@ impl PacketBuilder {
         bytes[0] = (bytes[0] | 0x02) & 0xFE;
         MacAddr::new(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5])
     }
-
 
 }

--- a/src/pkt_kit/pkt_builder.rs
+++ b/src/pkt_kit/pkt_builder.rs
@@ -12,15 +12,21 @@ use crate::utils::{default_ipv4_addr, default_iface_mac};
 
 
 #[derive(Default)]
-struct PacketBuffer {
+struct HeaderBuffer {
     tcp:   [u8; 20],
     ip:    [u8; 20],
     ether: [u8; 14],
 }
 
+struct PacketBuffer {
+    tcp_layer2: [u8; 54],
+    tcp_layer3: [u8; 40],
+}
+
 
 pub struct PacketBuilder {
-    buffers: PacketBuffer,
+    headers: HeaderBuffer,
+    packets: PacketBuffer,
     src_ip:  Ipv4Addr,
     src_mac: MacAddr,
     rng:     ThreadRng,
@@ -31,7 +37,8 @@ impl PacketBuilder {
 
     pub fn new() -> Self {
         Self {
-            buffers: PacketBuffer::default(),
+            headers: HeaderBuffer::default(),
+            packets: PacketBuffer { tcp_layer2: [0;54], tcp_layer3: [0;40] },
             src_ip:  default_ipv4_addr(),
             src_mac: default_iface_mac(),
             rng:     rand::thread_rng(),
@@ -40,28 +47,26 @@ impl PacketBuilder {
 
 
 
-    pub fn build_tcp_ether_packet(&mut self, dst_ip: Ipv4Addr) -> [u8; 54] {
+    pub fn build_tcp_ether_packet(&mut self, dst_ip: Ipv4Addr) -> &[u8] {
         self.add_ether_header();
         self.add_ip_header(dst_ip, IpNextHeaderProtocols::Tcp);
         self.add_tcp_header(dst_ip, 80);
         
-        let mut packet = [0u8; 54];
-        packet[..14].copy_from_slice(&self.buffers.ether);
-        packet[14..34].copy_from_slice(&self.buffers.ip);
-        packet[34..].copy_from_slice(&self.buffers.tcp);
-        packet
+        self.packets.tcp_layer2[..14].copy_from_slice(&self.headers.ether);
+        self.packets.tcp_layer2[14..34].copy_from_slice(&self.headers.ip);
+        self.packets.tcp_layer2[34..].copy_from_slice(&self.headers.tcp);
+        &self.packets.tcp_layer2
     }
 
 
 
-    pub fn build_tcp_ip_packet(&mut self, dst_ip: Ipv4Addr, dst_port: u16) -> [u8; 40] {
+    pub fn build_tcp_ip_packet(&mut self, dst_ip: Ipv4Addr, dst_port: u16) -> &[u8] {
         self.add_ip_header(dst_ip, IpNextHeaderProtocols::Tcp);
         self.add_tcp_header(dst_ip, dst_port);
         
-        let mut packet = [0u8; 40];
-        packet[..20].copy_from_slice(&self.buffers.ip);
-        packet[20..].copy_from_slice(&self.buffers.tcp);
-        packet
+        self.packets.tcp_layer3[..20].copy_from_slice(&self.headers.ip);
+        self.packets.tcp_layer3[20..].copy_from_slice(&self.headers.tcp);
+        &self.packets.tcp_layer3
     }
 
 
@@ -69,7 +74,7 @@ impl PacketBuilder {
     fn add_tcp_header(&mut self, dst_ip: Ipv4Addr, dst_port: u16) {
         let src_port = self.rng.gen_range(10000..=65535);
         
-        let mut tcp_header = MutableTcpPacket::new(&mut self.buffers.tcp).unwrap();
+        let mut tcp_header = MutableTcpPacket::new(&mut self.headers.tcp).unwrap();
         tcp_header.set_source(src_port);
         tcp_header.set_destination(dst_port);
         tcp_header.set_sequence(1);
@@ -84,7 +89,7 @@ impl PacketBuilder {
 
 
     fn add_ip_header(&mut self, dst_ip:Ipv4Addr, protocol: IpNextHeaderProtocol) {
-        let mut ip_header = MutableIpv4Packet::new(&mut self.buffers.ip).unwrap();
+        let mut ip_header = MutableIpv4Packet::new(&mut self.headers.ip).unwrap();
         ip_header.set_version(4);
         ip_header.set_header_length(5);
         ip_header.set_total_length(40);
@@ -101,7 +106,7 @@ impl PacketBuilder {
 
     fn add_ether_header(&mut self) {
         let dst_mac        = self.random_mac();
-        let mut eth_header = MutableEthernetPacket::new(&mut self.buffers.ether).unwrap();
+        let mut eth_header = MutableEthernetPacket::new(&mut self.headers.ether).unwrap();
         eth_header.set_source(self.src_mac);
         eth_header.set_destination(dst_mac);
         eth_header.set_ethertype(EtherTypes::Ipv4);

--- a/src/pkt_kit/pkt_sender.rs
+++ b/src/pkt_kit/pkt_sender.rs
@@ -53,7 +53,7 @@ impl PacketSender {
 
 
 
-    pub fn send_layer3_tcp(&mut self, packet: [u8; 40], dst_ip: Ipv4Addr) {
+    pub fn send_layer3_tcp(&mut self, packet: &[u8], dst_ip: Ipv4Addr) {
         self.layer3_tcp_socket.send_to(
             MutableIpv4Packet::owned(packet.to_vec()).unwrap(),
             std::net::IpAddr::V4(dst_ip)

--- a/src/pkt_kit/pkt_sender.rs
+++ b/src/pkt_kit/pkt_sender.rs
@@ -1,30 +1,60 @@
 use std::net::Ipv4Addr;
 use pnet::{
+    datalink::{self, Channel::Ethernet, DataLinkSender},
     packet::{ip::IpNextHeaderProtocols, ipv4::MutableIpv4Packet},
     transport::{transport_channel, TransportChannelType::Layer3, TransportSender},
 };
+use crate::utils::get_iface_name;
 
 
 
 pub struct PacketSender {
-    tcp_socket: TransportSender,
+    layer2_socket:     DataLinkSender,
+    layer3_tcp_socket: TransportSender,
 }
 
 
 impl PacketSender {
 
     pub fn new() -> Self{
+        Self {
+            layer2_socket:     Self::create_layer2_sender(),
+            layer3_tcp_socket: Self::create_layer3_tcp_socket(),
+        }
+    }
+
+
+
+    fn create_layer2_sender() -> DataLinkSender {
+        let iface_name = get_iface_name();
+        
+        let interface  = datalink::interfaces()
+            .into_iter()
+            .find(|iface| iface.name == iface_name)
+            .expect("Interface not found");
+
+        let (tx, _rx) = match datalink::channel(&interface, Default::default()) {
+            Ok(Ethernet(tx, rx)) => (tx, rx),
+            Ok(_)  => panic!("Unhandled channel type"),
+            Err(e) => panic!("Error creating datalink channel: {}", e),
+        };
+
+        tx
+    }
+
+    
+
+    fn create_layer3_tcp_socket() -> TransportSender {
         let (tcp_sender, _) = transport_channel(4096, Layer3(IpNextHeaderProtocols::Tcp))
             .expect("[ERROR] Could not create TCP transport channel");
         
-        Self {
-            tcp_socket: tcp_sender,
-        }
+        tcp_sender
     }
-    
 
-    pub fn send_tcp(&mut self, packet: [u8; 40], dst_ip: Ipv4Addr) {
-        self.tcp_socket.send_to(
+
+
+    pub fn send_layer3_tcp(&mut self, packet: [u8; 40], dst_ip: Ipv4Addr) {
+        self.layer3_tcp_socket.send_to(
             MutableIpv4Packet::owned(packet.to_vec()).unwrap(),
             std::net::IpAddr::V4(dst_ip)
         ).unwrap();

--- a/src/pkt_kit/pkt_sender.rs
+++ b/src/pkt_kit/pkt_sender.rs
@@ -4,12 +4,12 @@ use pnet::{
     packet::{ip::IpNextHeaderProtocols, ipv4::MutableIpv4Packet},
     transport::{transport_channel, TransportChannelType::Layer3, TransportSender},
 };
-use crate::utils::get_iface_name;
+use crate::utils::default_iface_name;
 
 
 
 pub struct PacketSender {
-    layer2_socket:     DataLinkSender,
+    layer2_socket:     Box<dyn DataLinkSender>,
     layer3_tcp_socket: TransportSender,
 }
 
@@ -25,8 +25,8 @@ impl PacketSender {
 
 
 
-    fn create_layer2_sender() -> DataLinkSender {
-        let iface_name = get_iface_name();
+    fn create_layer2_sender() -> Box<dyn DataLinkSender> {
+        let iface_name = default_iface_name();
         
         let interface  = datalink::interfaces()
             .into_iter()

--- a/src/pkt_kit/pkt_sender.rs
+++ b/src/pkt_kit/pkt_sender.rs
@@ -53,6 +53,14 @@ impl PacketSender {
 
 
 
+    pub fn send_layer2_frame(&mut self, packet: &[u8]) {
+        self.layer2_socket.send_to(packet, None)
+            .expect("Failed to send frame via datalink");
+    }
+
+
+
+
     pub fn send_layer3_tcp(&mut self, packet: &[u8], dst_ip: Ipv4Addr) {
         self.layer3_tcp_socket.send_to(
             MutableIpv4Packet::owned(packet.to_vec()).unwrap(),

--- a/src/utils/displays.rs
+++ b/src/utils/displays.rs
@@ -7,7 +7,7 @@ pub fn abort(error: impl Into<String>) -> ! {
 }
 
 
-pub fn display_progress(message: String) {
+pub fn inline_display(message: String) {
     print!("\r{}", message);
     io::stdout().flush().unwrap();
 }

--- a/src/utils/iface_info.rs
+++ b/src/utils/iface_info.rs
@@ -6,6 +6,14 @@ use crate::utils::abort;
 
 
 
+pub fn default_iface_name() -> String {
+    let iface_info = get_default_interface()
+        .expect("[ERROR] It wasn't possible to get the interface information");
+
+    iface_info.name
+}
+
+
 pub fn default_ipv4_net() -> Ipv4Net {
     let iface_info = get_default_interface()
         .expect("[ ERROR ] It wasn't possible to get the interface information");

--- a/src/utils/iface_info.rs
+++ b/src/utils/iface_info.rs
@@ -1,6 +1,8 @@
 use std::net::Ipv4Addr;
 use ipnet::Ipv4Net;
 use netdev::interface::get_default_interface;
+use pnet::datalink::{self, MacAddr};
+use crate::utils::abort;
 
 
 
@@ -24,4 +26,22 @@ pub fn default_iface_cidr() -> String {
     let network_addr = iface_info.network();
     let cidr         = iface_info.prefix_len();
     format!("{}/{}", network_addr, cidr)
+}
+
+
+pub fn default_iface_mac() -> MacAddr {
+    let my_ip = default_ipv4_addr();
+    let interfaces = datalink::interfaces();
+
+    for iface in interfaces {
+        for ip_network in iface.ips {
+            if let std::net::IpAddr::V4(v4) = ip_network.ip() {
+                if v4 == my_ip {
+                    return iface.mac
+                        .expect("[ERROR] The default interface does not have a MAC address");
+                }
+            }
+        }
+    }
+    abort(format!("[ERROR] Could not find the default interface with IP {}", my_ip));
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,7 +2,7 @@ pub mod delay_generator;
 pub use delay_generator::DelayTimeGenerator;
 
 pub mod displays;
-pub use displays::{abort, display_progress};
+pub use displays::{abort, inline_display};
 
 pub mod iface_info;
 pub use iface_info::*;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,7 +5,7 @@ pub mod displays;
 pub use displays::{abort, display_progress};
 
 pub mod iface_info;
-pub use iface_info::{default_ipv4_net, default_ipv4_addr, default_iface_cidr};
+pub use iface_info::*;
 
 pub mod dns;
 pub use dns::get_host_name;


### PR DESCRIPTION
Adds packet flooding functionality. Refactors parts of the packet creation pipeline to improve resource usage and introduces Ethernet-layer packet creation for the flooder. Also extends the packet sender with a method to send flood packets.

### Changes
- Add flooder mode that sends Ethernet-layer packets.
- Refactor packet builder to support building packets with an Ethernet layer (used by the flooder).
- Refactor resource-heavy blocks in the packet creation pipeline to reduce memory/cpu overhead.

### Motivation
- Enable efficient high-throughput packet generation for testing or lab scenarios that require raw Ethernet frames.
- Reduce memory and CPU overhead during packet construction to improve performance under high load.