### PR TITLE
Add UDP packet builders (Ether/IP/UDP & IP/UDP) and PacketFlooder for UDP/TCP sending

### DIFF
--- a/src/arg_parser/pscan_parser.rs
+++ b/src/arg_parser/pscan_parser.rs
@@ -28,4 +28,9 @@ pub struct PortScanArgs {
     #[arg(short, long)]
     pub delay: Option<String>,
 
+    
+    /// Scan UDP ports
+    #[arg(short = 'U', long = "UDP")]
+    pub udp: bool,
+
 }

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -53,9 +53,14 @@ impl PacketFlood {
         let (mut pkt_builder, mut pkt_sender) = Self::setup_tools();
 
         while true {
-            let ip  = self.get_random_ip();
-            let pkt = pkt_builder.build_tcp_ether_packet(ip);
-            pkt_sender.send_layer2_frame(pkt);
+            let ip = self.get_random_ip();
+            
+            let tcp_pkt = pkt_builder.build_tcp_ether_packet(ip);
+            pkt_sender.send_layer2_frame(tcp_pkt);
+
+            let udp_pkt = pkt_builder.build_udp_ether_packet(ip);
+            pkt_sender.send_layer2_frame(udp_pkt);
+            
             self.display_progress();
         }
 
@@ -64,7 +69,7 @@ impl PacketFlood {
 
     
     fn display_progress(&mut self) {
-        self.pkts_sent += 1;
+        self.pkts_sent += 2;
         let msg: String = format!("Packets sent: {}", &self.pkts_sent);
         inline_display(msg);
     }

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -52,7 +52,7 @@ impl PacketFlood {
     fn send_endlessly(&mut self) {
         let (mut pkt_builder, mut pkt_sender) = Self::setup_tools();
 
-        while true {
+        loop {
             let ip = self.get_random_ip();
             
             let tcp_pkt = pkt_builder.build_tcp_ether_packet(ip);
@@ -63,8 +63,6 @@ impl PacketFlood {
             
             self.display_progress();
         }
-
-        println!("");
     }
 
     

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -1,14 +1,15 @@
 use std::net::Ipv4Addr;
 use rand::{Rng, rngs::ThreadRng};
 use crate::pkt_kit::{PacketBuilder, PacketSender};
-use crate::utils::{default_ipv4_net};
+use crate::utils::{default_ipv4_net, inline_display};
 
 
 
 pub struct PacketFlood {
-    start: u32,
-    end:   u32,
-    rng:   ThreadRng,
+    start:     u32,
+    end:       u32,
+    pkts_sent: usize,
+    rng:       ThreadRng,
 }
 
 
@@ -16,9 +17,10 @@ impl PacketFlood {
 
     pub fn new() -> Self {
         Self {
-            start: 0,
-            end:   0,
-            rng:   rand::thread_rng(),
+            start:     0,
+            end:       0,
+            pkts_sent: 0,
+            rng:       rand::thread_rng(),
         }
     }
 
@@ -54,9 +56,18 @@ impl PacketFlood {
             let ip  = self.get_random_ip();
             let pkt = pkt_builder.build_tcp_ether_packet(ip);
             pkt_sender.send_layer2_frame(pkt);
+            self.display_progress();
         }
+
+        println!("");
     }
 
+    
+    fn display_progress(&mut self) {
+        self.pkts_sent += 1;
+        let msg: String = format!("Packets sent: {}", &self.pkts_sent);
+        inline_display(msg);
+    }
 
 
     fn get_random_ip(&mut self) -> Ipv4Addr {

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -10,6 +10,7 @@ pub struct PortScanner {
     return_data: bool,
     raw_packets: Vec<Vec<u8>>,
     open_ports:  Vec<String>,
+    ports:       Vec<u16>
 }
 
 
@@ -21,12 +22,14 @@ impl PortScanner {
             return_data,
             raw_packets: Vec::new(),
             open_ports:  Vec::new(),
+            ports:       Vec::new(),
         }
     }
 
 
 
     pub fn execute(&mut self) -> Vec<String> {
+        self.prepare_ports();
         self.send_and_receive();
         self.process_raw_packets();
         
@@ -36,6 +39,12 @@ impl PortScanner {
         
         self.display_result();
         Vec::new()
+    }
+
+
+
+    fn prepare_ports(&mut self) {
+        self.ports = PortGenerator::get_ports(self.args.ports.clone(), self.args.random.clone());
     }
 
 
@@ -51,7 +60,7 @@ impl PortScanner {
     fn setup_tools(&self) -> (PacketBuilder, PacketSender, PacketSniffer) {
         let pkt_builder     = PacketBuilder::new();
         let pkt_sender      = PacketSender::new();
-        let mut pkt_sniffer = PacketSniffer::new("pscan".to_string(), self.args.target_ip.to_string());
+        let mut pkt_sniffer = PacketSniffer::new(self.filter_key(), self.args.target_ip.to_string());
 
         pkt_sniffer.start_buffered_sniffer();
         thread::sleep(Duration::from_secs_f32(0.5));
@@ -61,13 +70,31 @@ impl PortScanner {
 
 
 
-    fn send_probes(&self, pkt_builder: &mut PacketBuilder, pkt_sender: &mut PacketSender) {
-        let (ip, ports, delays) = self.get_data_for_loop();
+    fn filter_key(&self) -> String {
+        if self.args.udp {
+            return "pscan-udp".to_string()
+        }
 
-        for (port, delay) in ports.iter().zip(delays.iter())  {
-            let tcp_packet = pkt_builder.build_tcp_ip_packet(self.args.target_ip, *port);
-            pkt_sender.send_layer3_tcp(tcp_packet, self.args.target_ip);
-            
+        "pscan-tcp".to_string()
+    }
+
+
+
+    fn send_probes(&self, pkt_builder: &mut PacketBuilder, pkt_sender: &mut PacketSender) {
+        let (ip, delays) = self.get_data_for_loop();
+
+        for (port, delay) in self.ports.iter().zip(delays.iter())  {
+
+            if !self.args.udp {
+                let tcp_packet = pkt_builder.build_tcp_ip_packet(self.args.target_ip, *port);
+                pkt_sender.send_layer3_tcp(tcp_packet, self.args.target_ip);
+            }
+
+            if self.args.udp {
+                let udp_packet = pkt_builder.build_udp_ip_packet(self.args.target_ip, *port);
+                pkt_sender.send_layer3_udp(udp_packet, self.args.target_ip);
+            }
+
             Self::display_progress(ip.clone(), *port, *delay);
             thread::sleep(Duration::from_secs_f32(*delay));
         }
@@ -76,11 +103,10 @@ impl PortScanner {
 
 
 
-    fn get_data_for_loop(&self) -> (String, Vec<u16>, Vec<f32>) {
+    fn get_data_for_loop(&self) -> (String, Vec<f32>) {
         let ip     = self.args.target_ip.to_string();
-        let ports  = PortGenerator::get_ports(self.args.ports.clone(), self.args.random.clone());
-        let delays = DelayTimeGenerator::get_delay_list(self.args.delay.clone(), ports.len());
-        (ip, ports, delays)
+        let delays = DelayTimeGenerator::get_delay_list(self.args.delay.clone(), self.ports.len());
+        (ip, delays)
     }
 
 
@@ -101,10 +127,46 @@ impl PortScanner {
 
 
     fn process_raw_packets(&mut self) {
+        if self.args.udp {
+            self.process_udp_packets();
+        } else {
+            self.process_tcp_packets();
+        }
+    }
+
+
+
+    fn process_tcp_packets(&mut self) {
         for packet in &self.raw_packets {
-            let port = PacketDissector::get_src_port(packet);
+            let port = PacketDissector::get_tcp_src_port(packet);
             self.open_ports.push(port);
         }
+    }
+
+
+
+    fn process_udp_packets(&mut self) {
+        let mut closed_ports: Vec<u16> = Vec::new();
+
+        for packet in &self.raw_packets {
+            let port = PacketDissector::extract_udp_dst_port_from_icmp(packet);
+            if let Some(p) = port{
+                closed_ports.push(p);
+            }
+        }
+
+        self.remove_closed(&closed_ports);
+    }
+
+
+
+    fn remove_closed(&mut self, closed_ports: &[u16]) {
+        self.open_ports = self.ports
+            .iter()
+            .copied()
+            .filter(|port| !closed_ports.contains(port))
+            .map(|port| port.to_string())
+            .collect();
     }
 
 

--- a/src/pkt_kit/mod.rs
+++ b/src/pkt_kit/mod.rs
@@ -1,3 +1,6 @@
+pub mod pkt_buffer;
+pub use pkt_buffer::{HeaderBuffer, PacketBuffer};
+
 pub mod pkt_builder;
 pub use pkt_builder::PacketBuilder;
 

--- a/src/pkt_kit/pkt_buffer.rs
+++ b/src/pkt_kit/pkt_buffer.rs
@@ -21,6 +21,7 @@ impl Default for HeaderBuffer {
 pub struct PacketBuffer {
     pub tcp_layer2: [u8; 54],
     pub tcp_layer3: [u8; 40],
+    pub udp_layer2: [u8; 42],
     pub udp_layer3: [u8; 28],
 }
 
@@ -29,6 +30,7 @@ impl Default for PacketBuffer {
         Self {
             tcp_layer2: [0; 54],
             tcp_layer3: [0; 40],
+            udp_layer2: [0; 42],
             udp_layer3: [0; 28],
         }
     }

--- a/src/pkt_kit/pkt_buffer.rs
+++ b/src/pkt_kit/pkt_buffer.rs
@@ -1,0 +1,35 @@
+pub struct HeaderBuffer {
+    pub tcp:   [u8; 20],
+    pub udp:   [u8; 8],
+    pub ip:    [u8; 20],
+    pub ether: [u8; 14],
+}
+
+impl Default for HeaderBuffer {
+    fn default() -> Self {
+        Self {
+            tcp:   [0; 20],
+            udp:   [0; 8],
+            ip:    [0; 20],
+            ether: [0; 14],
+        }
+    }
+}
+
+
+
+pub struct PacketBuffer {
+    pub tcp_layer2: [u8; 54],
+    pub tcp_layer3: [u8; 40],
+    pub udp_layer3: [u8; 28],
+}
+
+impl Default for PacketBuffer {
+    fn default() -> Self {
+        Self {
+            tcp_layer2: [0; 54],
+            tcp_layer3: [0; 40],
+            udp_layer3: [0; 28],
+        }
+    }
+}

--- a/src/pkt_kit/pkt_builder.rs
+++ b/src/pkt_kit/pkt_builder.rs
@@ -6,22 +6,11 @@ use pnet::packet::{
     ip::{IpNextHeaderProtocols, IpNextHeaderProtocol},
     ipv4::{MutableIpv4Packet, checksum as ip_checksum},
     tcp::{MutableTcpPacket, TcpFlags, ipv4_checksum as tcp_checksum},
+    udp::{MutableUdpPacket, ipv4_checksum as udp_checksum},
 };
+use crate::pkt_kit::{HeaderBuffer, PacketBuffer};
 use crate::utils::{default_ipv4_addr, default_iface_mac};
 
-
-
-#[derive(Default)]
-struct HeaderBuffer {
-    tcp:   [u8; 20],
-    ip:    [u8; 20],
-    ether: [u8; 14],
-}
-
-struct PacketBuffer {
-    tcp_layer2: [u8; 54],
-    tcp_layer3: [u8; 40],
-}
 
 
 pub struct PacketBuilder {
@@ -38,7 +27,7 @@ impl PacketBuilder {
     pub fn new() -> Self {
         Self {
             headers: HeaderBuffer::default(),
-            packets: PacketBuffer { tcp_layer2: [0;54], tcp_layer3: [0;40] },
+            packets: PacketBuffer::default(),
             src_ip:  default_ipv4_addr(),
             src_mac: default_iface_mac(),
             rng:     rand::thread_rng(),
@@ -71,6 +60,17 @@ impl PacketBuilder {
 
 
 
+    pub fn build_udp_ip_packet(&mut self, dst_ip: Ipv4Addr, dst_port: u16) -> &[u8] {
+        self.add_ip_header(dst_ip, IpNextHeaderProtocols::Udp);
+        self.add_udp_header(dst_ip, dst_port);
+
+        self.packets.udp_layer3[..20].copy_from_slice(&self.headers.ip);
+        self.packets.udp_layer3[20..].copy_from_slice(&self.headers.udp);
+        &self.packets.udp_layer3
+    }
+
+
+
     fn add_tcp_header(&mut self, dst_ip: Ipv4Addr, dst_port: u16) {
         let src_port = self.rng.gen_range(10000..=65535);
         
@@ -84,6 +84,20 @@ impl PacketBuilder {
 
         let pseudo_header_sum = tcp_checksum(&tcp_header.to_immutable(), &self.src_ip, &dst_ip);
         tcp_header.set_checksum(pseudo_header_sum);
+    }
+
+
+
+    fn add_udp_header(&mut self, dst_ip: Ipv4Addr, dst_port: u16) {
+        let src_port = self.rng.gen_range(10000..=65535);
+
+        let mut udp_header = MutableUdpPacket::new(&mut self.headers.udp).unwrap();
+        udp_header.set_source(src_port);
+        udp_header.set_destination(dst_port);
+        udp_header.set_length(8u16);
+
+        let checksum = udp_checksum(&udp_header.to_immutable(), &self.src_ip, &dst_ip);
+        udp_header.set_checksum(checksum);
     }
 
 

--- a/src/pkt_kit/pkt_builder.rs
+++ b/src/pkt_kit/pkt_builder.rs
@@ -60,10 +60,10 @@ impl PacketBuilder {
 
 
 
-    pub fn build_udp_ether_packet(&mut self, dst_ip: Ipv4Addr, dst_port: u16) -> &[u8] {
+    pub fn build_udp_ether_packet(&mut self, dst_ip: Ipv4Addr) -> &[u8] {
         self.add_ether_header();
         self.add_ip_header(28, IpNextHeaderProtocols::Udp, dst_ip);
-        self.add_udp_header(dst_ip, dst_port);
+        self.add_udp_header(dst_ip, 53);
 
         self.packets.udp_layer2[..14].copy_from_slice(&self.headers.ether);
         self.packets.udp_layer2[14..34].copy_from_slice(&self.headers.ip);

--- a/src/pkt_kit/pkt_dissector.rs
+++ b/src/pkt_kit/pkt_dissector.rs
@@ -1,4 +1,4 @@
-use etherparse::{SlicedPacket, InternetSlice, LinkSlice, Ipv4HeaderSlice};
+use etherparse::{SlicedPacket, InternetSlice, LinkSlice};
 
 pub struct PacketDissector;
 
@@ -31,28 +31,6 @@ impl PacketDissector {
                 _ => None,
             })
             .unwrap_or_else(|| "unknown".to_string())
-    }
-
-
-    
-    pub fn extract_udp_dst_port_from_icmp(frame: &[u8]) -> Option<u16> {
-        let outer_ipv4 = Ipv4HeaderSlice::from_slice(frame).ok()?;
-        let ihl_bytes  = (outer_ipv4.ihl() as usize) * 4;
-
-        let icmp_start        = ihl_bytes;
-        let embedded_ip_start = icmp_start + 8;
-
-        let inner_ipv4      = Ipv4HeaderSlice::from_slice(&frame[embedded_ip_start..]).ok()?;
-        let inner_ihl_bytes = (inner_ipv4.ihl() as usize) * 4;
-
-        let embedded_udp_start = embedded_ip_start + inner_ihl_bytes;
-
-        if frame.len() < embedded_udp_start + 4 {
-            return None;
-        }
-
-        let dst_port = u16::from_be_bytes([frame[embedded_udp_start + 2], frame[embedded_udp_start + 3],]);
-        Some(dst_port)
     }
 
 

--- a/src/pkt_kit/pkt_sender.rs
+++ b/src/pkt_kit/pkt_sender.rs
@@ -54,8 +54,8 @@ impl PacketSender {
 
 
     pub fn send_layer2_frame(&mut self, packet: &[u8]) {
-        self.layer2_socket.send_to(packet, None)
-            .expect("Failed to send frame via datalink");
+        let _ = self.layer2_socket.send_to(packet, None)
+                    .expect("Failed to send frame via datalink");
     }
 
 

--- a/src/pkt_kit/pkt_sender.rs
+++ b/src/pkt_kit/pkt_sender.rs
@@ -11,6 +11,7 @@ use crate::utils::default_iface_name;
 pub struct PacketSender {
     layer2_socket:     Box<dyn DataLinkSender>,
     layer3_tcp_socket: TransportSender,
+    layer3_udp_socket: TransportSender,
 }
 
 
@@ -20,6 +21,7 @@ impl PacketSender {
         Self {
             layer2_socket:     Self::create_layer2_sender(),
             layer3_tcp_socket: Self::create_layer3_tcp_socket(),
+            layer3_udp_socket: Self::create_layer3_udp_socket()
         }
     }
 
@@ -53,6 +55,15 @@ impl PacketSender {
 
 
 
+    fn create_layer3_udp_socket() -> TransportSender {
+        let (udp_sender, _) = transport_channel(4096, Layer3(IpNextHeaderProtocols::Udp))
+            .expect("[ERROR] Could not create UDP transport channel");
+
+        udp_sender
+    }
+
+
+
     pub fn send_layer2_frame(&mut self, packet: &[u8]) {
         let _ = self.layer2_socket.send_to(packet, None)
                     .expect("Failed to send frame via datalink");
@@ -63,6 +74,15 @@ impl PacketSender {
 
     pub fn send_layer3_tcp(&mut self, packet: &[u8], dst_ip: Ipv4Addr) {
         self.layer3_tcp_socket.send_to(
+            MutableIpv4Packet::owned(packet.to_vec()).unwrap(),
+            std::net::IpAddr::V4(dst_ip)
+        ).unwrap();
+    }
+
+
+
+    pub fn send_layer3_udp(&mut self, packet: &[u8], dst_ip: Ipv4Addr) {
+        self.layer3_udp_socket.send_to(
             MutableIpv4Packet::owned(packet.to_vec()).unwrap(),
             std::net::IpAddr::V4(dst_ip)
         ).unwrap();

--- a/src/pkt_kit/pkt_sender.rs
+++ b/src/pkt_kit/pkt_sender.rs
@@ -71,7 +71,6 @@ impl PacketSender {
 
 
 
-
     pub fn send_layer3_tcp(&mut self, packet: &[u8], dst_ip: Ipv4Addr) {
         self.layer3_tcp_socket.send_to(
             MutableIpv4Packet::owned(packet.to_vec()).unwrap(),

--- a/src/pkt_kit/pkt_sniffer.rs
+++ b/src/pkt_kit/pkt_sniffer.rs
@@ -91,9 +91,10 @@ impl PacketSniffer {
         let my_ip = default_ipv4_addr().to_string();
 
         match self.command.as_str() {
-            "netmap" => format!("tcp and dst host {} and src net {}", my_ip, default_iface_cidr()),
-            "pscan"  => format!("tcp[13] & 0x12 == 0x12 and dst host {} and src host {}", my_ip, self.src_ip),
-            _        => panic!("[ ERROR ] Unknown filter: {}", self.command),
+            "netmap"    => format!("tcp and dst host {} and src net {}", my_ip, default_iface_cidr()),
+            "pscan-tcp" => format!("tcp[13] & 0x12 == 0x12 and dst host {} and src host {}", my_ip, self.src_ip),
+            "pscan-udp" => format!("icmp and icmp[0] == 3 and icmp[1] == 3 and dst host {} and src host {}", my_ip, self.src_ip),
+            _           => panic!("[ ERROR ] Unknown filter: {}", self.command),
         }
     }
 

--- a/src/utils/delay_generator.rs
+++ b/src/utils/delay_generator.rs
@@ -8,7 +8,7 @@ impl DelayTimeGenerator {
 
     pub fn get_delay_list(delay_arg: Option<String>, quantity: usize) -> Vec<f32> {
         if delay_arg.is_none() {
-            return Self::fixed_delay_range("0.02".to_string(), quantity)
+            return Self::fixed_delay_range("0.04".to_string(), quantity)
         }
 
         let delay_str = delay_arg.unwrap();


### PR DESCRIPTION
Adds UDP packet builders with support for `Ether/IP/UDP` and `IP/UDP` stacks, and introduces `PacketFlooder`, a component that performs UDP and TCP packet sending. 
***Note***: UDP scanning using the IP (IP/UDP) path is planned but not yet implemented.