### PR TITLE
Specific or random IPs in layer 2 packets

### DIFF
--- a/src/arg_parser/flood_args.rs
+++ b/src/arg_parser/flood_args.rs
@@ -1,0 +1,18 @@
+pub use std::net::Ipv4Addr;
+pub use clap::Parser;
+
+
+#[derive(Parser)]
+#[command(name = "flood", about = "Packet Flooder")]
+pub struct FloodArgs {
+
+    /// Define a source IP
+    #[arg(long = "src-ip")]
+    pub src_ip: Option<Ipv4Addr>,
+
+
+    /// Define a destination IP
+    #[arg(long = "dst-ip")]
+    pub dst_ip: Option<Ipv4Addr>,
+
+}

--- a/src/arg_parser/mod.rs
+++ b/src/arg_parser/mod.rs
@@ -1,3 +1,6 @@
+pub mod flood_args;
+pub use flood_args::FloodArgs;
+
 pub mod netmap_parser;
 pub use netmap_parser::NetMapArgs;
 

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -1,11 +1,13 @@
 use std::net::Ipv4Addr;
 use rand::{Rng, rngs::ThreadRng};
+use crate::arg_parser::FloodArgs;
 use crate::pkt_kit::{PacketBuilder, PacketSender};
 use crate::utils::{default_ipv4_net, inline_display};
 
 
 
 pub struct PacketFlood {
+    args:      FloodArgs,
     start:     u32,
     end:       u32,
     pkts_sent: usize,
@@ -15,8 +17,9 @@ pub struct PacketFlood {
 
 impl PacketFlood {
 
-    pub fn new() -> Self {
+    pub fn new(args: FloodArgs) -> Self {
         Self {
+            args,
             start:     0,
             end:       0,
             pkts_sent: 0,

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -56,19 +56,33 @@ impl PacketFlood {
         let (mut pkt_builder, mut pkt_sender) = Self::setup_tools();
 
         loop {
-            let ip = self.get_random_ip();
+            let src_ip = self.get_src_ip();
+            let dst_ip = self.get_dst_ip();
             
-            let tcp_pkt = pkt_builder.build_tcp_ether_packet(ip);
+            let tcp_pkt = pkt_builder.build_tcp_ether_packet(src_ip, dst_ip);
             pkt_sender.send_layer2_frame(tcp_pkt);
 
-            let udp_pkt = pkt_builder.build_udp_ether_packet(ip);
+            let udp_pkt = pkt_builder.build_udp_ether_packet(src_ip, dst_ip);
             pkt_sender.send_layer2_frame(udp_pkt);
             
             self.display_progress();
         }
     }
 
+
+
+    fn get_src_ip(&mut self) -> Ipv4Addr {
+        self.args.src_ip.unwrap_or_else(|| self.get_random_ip())
+    }
+
+
+
+    fn get_dst_ip(&mut self) -> Ipv4Addr {
+        self.args.dst_ip.unwrap_or_else(|| self.get_random_ip())
+    }
+
     
+
     fn display_progress(&mut self) {
         self.pkts_sent += 2;
         let msg: String = format!("Packets sent: {}", &self.pkts_sent);

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,8 @@ impl Command {
 
 
     fn execute_flood(&self) {
-        let mut flood = PacketFlood::new();
+        let cmd_args  = FloodArgs::parse_from(self.arguments.clone());
+        let mut flood = PacketFlood::new(cmd_args);
         flood.execute();
     }
 


### PR DESCRIPTION
The Packet Builder was refactored to build layer 2 packets with specific (source and destination) or random IPs.