### PR TITLE
Add flag to select a network interface (only Flooder and Mapper)

### DIFF
--- a/src/arg_parser/flood_args.rs
+++ b/src/arg_parser/flood_args.rs
@@ -1,10 +1,16 @@
 pub use std::net::Ipv4Addr;
 pub use clap::Parser;
+use crate::utils::default_iface_name;
 
 
 #[derive(Parser)]
 #[command(name = "flood", about = "Packet Flooder")]
 pub struct FloodArgs {
+
+    /// Define a network interface to send the packets
+    #[arg(short, long, default_value_t = default_iface_name())]
+    pub iface: String,
+
 
     /// Define a source IP
     #[arg(long = "src-ip")]

--- a/src/arg_parser/netmap_parser.rs
+++ b/src/arg_parser/netmap_parser.rs
@@ -1,24 +1,30 @@
 pub use clap::Parser;
+use crate::utils::default_iface_name;
 
 
 #[derive(Parser)]
 #[command(name = "netmap", about = "Network Mapper")]
 pub struct NetMapArgs {
 
-    /// Send packets to hosts in random order
-    #[arg(short, long)]
-    pub random: bool,
-
-
     /// Add a delay between packet transmissions.
     ///
     /// Examples: 0.5 or 1-2 (seconds).
-    #[arg(short, long)]
-    pub delay: Option<String>,
+    #[arg(short, long, default_value = "0.04")]
+    pub delay: String,
+
+
+    /// Define a network interface to send the packets
+    #[arg(short, long, default_value_t = default_iface_name())]
+    pub iface: String,
 
 
     /// Scan ports on active hosts
     #[arg(short = 'P', long = "Portscan")]
     pub portscan: bool,
+
+
+    /// Send packets to hosts in random order
+    #[arg(short, long)]
+    pub random: bool,
 
 }

--- a/src/arg_parser/pscan_parser.rs
+++ b/src/arg_parser/pscan_parser.rs
@@ -25,8 +25,8 @@ pub struct PortScanArgs {
     /// Add a delay between packet transmissions.
     ///
     /// Examples: 0.5 or 1-2 (seconds).
-    #[arg(short, long)]
-    pub delay: Option<String>,
+    #[arg(short, long, default_value = "0.04")]
+    pub delay: String,
 
     
     /// Scan UDP ports

--- a/src/arg_parser/pscan_parser.rs
+++ b/src/arg_parser/pscan_parser.rs
@@ -13,8 +13,8 @@ pub struct PortScanArgs {
     /// Scan specific ports or ranges of ports (can be combined).
     ///
     /// Examples: Specific: 22,80 | Range: 20-50 | Combined: 22,50-100
-    #[arg(short, long)]
-    pub ports: Option<String>,
+    #[arg(short, long, default_value = "0-100")]
+    pub ports: String,
 
 
     /// Scan the ports in random order

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -46,14 +46,14 @@ impl PacketFlood {
 
     fn setup_tools(&self) -> (PacketBuilder, Layer2PacketSender) {
         let pkt_builder = PacketBuilder::new();
-        let pkt_sender  = Layer2PacketSender::new(self.args.iface);
+        let pkt_sender  = Layer2PacketSender::new(self.args.iface.clone());
         (pkt_builder, pkt_sender)
     }
 
 
 
     fn send_endlessly(&mut self) {
-        let (mut pkt_builder, mut pkt_sender) = Self::setup_tools();
+        let (mut pkt_builder, mut pkt_sender) = self.setup_tools();
 
         loop {
             let src_ip = self.get_src_ip();

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -1,7 +1,7 @@
 use std::net::Ipv4Addr;
 use rand::{Rng, rngs::ThreadRng};
 use crate::arg_parser::FloodArgs;
-use crate::pkt_kit::{PacketBuilder, PacketSender};
+use crate::pkt_kit::{PacketBuilder, Layer2PacketSender};
 use crate::utils::{default_ipv4_net, inline_display};
 
 
@@ -44,9 +44,9 @@ impl PacketFlood {
 
 
 
-    fn setup_tools() -> (PacketBuilder, PacketSender) {
+    fn setup_tools(&self) -> (PacketBuilder, Layer2PacketSender) {
         let pkt_builder = PacketBuilder::new();
-        let pkt_sender  = PacketSender::new();
+        let pkt_sender  = Layer2PacketSender::new(self.args.iface);
         (pkt_builder, pkt_sender)
     }
 

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -2,7 +2,7 @@ use std::net::Ipv4Addr;
 use rand::{Rng, rngs::ThreadRng};
 use crate::arg_parser::FloodArgs;
 use crate::pkt_kit::{PacketBuilder, Layer2PacketSender};
-use crate::utils::{default_ipv4_net, inline_display};
+use crate::utils::{get_ipv4_net, inline_display};
 
 
 
@@ -37,23 +37,23 @@ impl PacketFlood {
 
 
     fn set_ip_range(&mut self) {
-        let net    = default_ipv4_net();
+        let net    = get_ipv4_net(&self.args.iface);
         self.start = net.network().into();
         self.end   = net.broadcast().into();
     }
 
 
 
-    fn setup_tools(&self) -> (PacketBuilder, Layer2PacketSender) {
-        let pkt_builder = PacketBuilder::new();
-        let pkt_sender  = Layer2PacketSender::new(self.args.iface.clone());
+    fn setup_tools(iface: String) -> (PacketBuilder, Layer2PacketSender) {
+        let pkt_builder = PacketBuilder::new(iface.clone());
+        let pkt_sender  = Layer2PacketSender::new(iface.clone());
         (pkt_builder, pkt_sender)
     }
 
 
 
     fn send_endlessly(&mut self) {
-        let (mut pkt_builder, mut pkt_sender) = self.setup_tools();
+        let (mut pkt_builder, mut pkt_sender) = Self::setup_tools(self.args.iface.clone());
 
         loop {
             let src_ip = self.get_src_ip();

--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use ipnet::Ipv4AddrRange;
 use crate::arg_parser::{NetMapArgs, PortScanArgs};
 use crate::engines::PortScanner;
-use crate::pkt_kit::{PacketBuilder, PacketDissector, PacketSender, PacketSniffer};
+use crate::pkt_kit::{PacketBuilder, PacketDissector, Layer3PacketSender, PacketSniffer};
 use crate::utils::{inline_display, default_ipv4_net, get_host_name, DelayTimeGenerator};
 
 
@@ -43,9 +43,9 @@ impl NetworkMapper {
 
 
 
-    fn setup_tools() -> (PacketBuilder, PacketSender, PacketSniffer) {
+    fn setup_tools() -> (PacketBuilder, Layer3PacketSender, PacketSniffer) {
         let pkt_builder     = PacketBuilder::new();
-        let pkt_sender      = PacketSender::new();
+        let pkt_sender      = Layer3PacketSender::new();
         let mut pkt_sniffer = PacketSniffer::new("netmap".to_string(), "".to_string());
 
         pkt_sniffer.start_buffered_sniffer();
@@ -54,7 +54,7 @@ impl NetworkMapper {
 
 
 
-    fn send_probes(&self, pkt_builder: &mut PacketBuilder, pkt_sender: &mut PacketSender) {
+    fn send_probes(&self, pkt_builder: &mut PacketBuilder, pkt_sender: &mut Layer3PacketSender) {
         let (ip_range, total, delays) = self.get_data_for_loop();
 
         for (i, (ip, delay)) in ip_range.into_iter().zip(delays.iter()).enumerate() {

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -1,6 +1,6 @@
 use std::{thread, time::Duration};
 use crate::arg_parser::PortScanArgs;
-use crate::pkt_kit::{PacketBuilder, PacketDissector, PacketSender, PacketSniffer};
+use crate::pkt_kit::{PacketBuilder, PacketDissector, Layer3PacketSender, PacketSniffer};
 use crate::utils::{PortGenerator, inline_display, get_host_name, DelayTimeGenerator};
 
 
@@ -57,9 +57,9 @@ impl PortScanner {
 
 
 
-    fn setup_tools(&self) -> (PacketBuilder, PacketSender, PacketSniffer) {
+    fn setup_tools(&self) -> (PacketBuilder, Layer3PacketSender, PacketSniffer) {
         let pkt_builder     = PacketBuilder::new();
-        let pkt_sender      = PacketSender::new();
+        let pkt_sender      = Layer3PacketSender::new();
         let mut pkt_sniffer = PacketSniffer::new(self.filter(), self.args.target_ip.to_string());
 
         pkt_sniffer.start_buffered_sniffer();
@@ -76,7 +76,7 @@ impl PortScanner {
 
 
 
-    fn send_probes(&self, pkt_builder: &mut PacketBuilder, pkt_sender: &mut PacketSender) {
+    fn send_probes(&self, pkt_builder: &mut PacketBuilder, pkt_sender: &mut Layer3PacketSender) {
         let (ip, delays) = self.get_data_for_loop();
 
         for (port, delay) in self.ports.iter().zip(delays.iter())  {

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -1,7 +1,7 @@
 use std::{thread, time::Duration};
 use crate::arg_parser::PortScanArgs;
 use crate::pkt_kit::{PacketBuilder, PacketDissector, Layer3PacketSender, PacketSniffer};
-use crate::utils::{PortGenerator, inline_display, get_host_name, DelayTimeGenerator};
+use crate::utils::{PortGenerator, inline_display, get_host_name, DelayTimeGenerator, default_iface_name};
 
 
 
@@ -58,9 +58,10 @@ impl PortScanner {
 
 
     fn setup_tools(&self) -> (PacketBuilder, Layer3PacketSender, PacketSniffer) {
-        let pkt_builder     = PacketBuilder::new();
+        let iface           = default_iface_name();
+        let pkt_builder     = PacketBuilder::new(iface.clone());
         let pkt_sender      = Layer3PacketSender::new();
-        let mut pkt_sniffer = PacketSniffer::new(self.filter(), self.args.target_ip.to_string());
+        let mut pkt_sniffer = PacketSniffer::new(self.filter(), iface.clone(), self.args.target_ip.to_string());
 
         pkt_sniffer.start_buffered_sniffer();
         thread::sleep(Duration::from_secs_f32(0.5));

--- a/src/pkt_kit/layer2_pkt_sender.rs
+++ b/src/pkt_kit/layer2_pkt_sender.rs
@@ -22,12 +22,12 @@ impl Layer2PacketSender {
         let interface  = datalink::interfaces()
             .into_iter()
             .find(|iface| iface.name == iface_name)
-            .expect("[ERROR] Interface not found");
+            .expect("[ ERROR ] Interface not found");
 
         let (tx, _rx) = match datalink::channel(&interface, Default::default()) {
             Ok(Ethernet(tx, rx)) => (tx, rx),
-            Ok(_)  => panic!("[ERROR] Unhandled channel type"),
-            Err(e) => panic!("[ERROR] Error creating datalink channel: {}", e),
+            Ok(_)  => panic!("[ ERROR ] Unhandled channel type"),
+            Err(e) => panic!("[ ERROR ] Error creating datalink channel: {}", e),
         };
 
         tx
@@ -36,7 +36,7 @@ impl Layer2PacketSender {
 
     pub fn send_layer2_frame(&mut self, packet: &[u8]) {
         let _ = self.layer2_socket.send_to(packet, None)
-                    .expect("[ERROR] Failed to send frame via datalink");
+                    .expect("[ ERROR ] Failed to send frame via datalink");
     }
 
 }

--- a/src/pkt_kit/layer2_pkt_sender.rs
+++ b/src/pkt_kit/layer2_pkt_sender.rs
@@ -1,0 +1,42 @@
+use pnet::datalink::{self, Channel::Ethernet, DataLinkSender};
+
+
+
+pub struct Layer2PacketSender {
+    layer2_socket:     Box<dyn DataLinkSender>,
+}
+
+
+
+impl Layer2PacketSender {
+
+    pub fn new(iface: String) -> Self{
+        Self {
+            layer2_socket: Self::create_layer2_sender(iface),
+        }
+    }
+
+
+
+    fn create_layer2_sender(iface_name: String) -> Box<dyn DataLinkSender> {        
+        let interface  = datalink::interfaces()
+            .into_iter()
+            .find(|iface| iface.name == iface_name)
+            .expect("Interface not found");
+
+        let (tx, _rx) = match datalink::channel(&interface, Default::default()) {
+            Ok(Ethernet(tx, rx)) => (tx, rx),
+            Ok(_)  => panic!("Unhandled channel type"),
+            Err(e) => panic!("Error creating datalink channel: {}", e),
+        };
+
+        tx
+    }
+
+
+    pub fn send_layer2_frame(&mut self, packet: &[u8]) {
+        let _ = self.layer2_socket.send_to(packet, None)
+                    .expect("Failed to send frame via datalink");
+    }
+
+}

--- a/src/pkt_kit/layer2_pkt_sender.rs
+++ b/src/pkt_kit/layer2_pkt_sender.rs
@@ -22,12 +22,12 @@ impl Layer2PacketSender {
         let interface  = datalink::interfaces()
             .into_iter()
             .find(|iface| iface.name == iface_name)
-            .expect("Interface not found");
+            .expect("[ERROR] Interface not found");
 
         let (tx, _rx) = match datalink::channel(&interface, Default::default()) {
             Ok(Ethernet(tx, rx)) => (tx, rx),
-            Ok(_)  => panic!("Unhandled channel type"),
-            Err(e) => panic!("Error creating datalink channel: {}", e),
+            Ok(_)  => panic!("[ERROR] Unhandled channel type"),
+            Err(e) => panic!("[ERROR] Error creating datalink channel: {}", e),
         };
 
         tx
@@ -36,7 +36,7 @@ impl Layer2PacketSender {
 
     pub fn send_layer2_frame(&mut self, packet: &[u8]) {
         let _ = self.layer2_socket.send_to(packet, None)
-                    .expect("Failed to send frame via datalink");
+                    .expect("[ERROR] Failed to send frame via datalink");
     }
 
 }

--- a/src/pkt_kit/layer3_pkt_sender.rs
+++ b/src/pkt_kit/layer3_pkt_sender.rs
@@ -1,6 +1,5 @@
 use std::net::Ipv4Addr;
 use pnet::{
-    datalink::{self, Channel::Ethernet, DataLinkSender},
     packet::{ip::IpNextHeaderProtocols, ipv4::MutableIpv4Packet},
     transport::{transport_channel, TransportChannelType::Layer3, TransportSender},
 };
@@ -8,40 +7,19 @@ use crate::utils::default_iface_name;
 
 
 
-pub struct PacketSender {
-    layer2_socket:     Box<dyn DataLinkSender>,
+pub struct Layer3PacketSender {
     layer3_tcp_socket: TransportSender,
     layer3_udp_socket: TransportSender,
 }
 
 
-impl PacketSender {
+impl Layer3PacketSender {
 
     pub fn new() -> Self{
         Self {
-            layer2_socket:     Self::create_layer2_sender(),
             layer3_tcp_socket: Self::create_layer3_tcp_socket(),
             layer3_udp_socket: Self::create_layer3_udp_socket()
         }
-    }
-
-
-
-    fn create_layer2_sender() -> Box<dyn DataLinkSender> {
-        let iface_name = default_iface_name();
-        
-        let interface  = datalink::interfaces()
-            .into_iter()
-            .find(|iface| iface.name == iface_name)
-            .expect("Interface not found");
-
-        let (tx, _rx) = match datalink::channel(&interface, Default::default()) {
-            Ok(Ethernet(tx, rx)) => (tx, rx),
-            Ok(_)  => panic!("Unhandled channel type"),
-            Err(e) => panic!("Error creating datalink channel: {}", e),
-        };
-
-        tx
     }
 
     
@@ -60,13 +38,6 @@ impl PacketSender {
             .expect("[ERROR] Could not create UDP transport channel");
 
         udp_sender
-    }
-
-
-
-    pub fn send_layer2_frame(&mut self, packet: &[u8]) {
-        let _ = self.layer2_socket.send_to(packet, None)
-                    .expect("Failed to send frame via datalink");
     }
 
 

--- a/src/pkt_kit/layer3_pkt_sender.rs
+++ b/src/pkt_kit/layer3_pkt_sender.rs
@@ -3,7 +3,6 @@ use pnet::{
     packet::{ip::IpNextHeaderProtocols, ipv4::MutableIpv4Packet},
     transport::{transport_channel, TransportChannelType::Layer3, TransportSender},
 };
-use crate::utils::default_iface_name;
 
 
 

--- a/src/pkt_kit/layer3_pkt_sender.rs
+++ b/src/pkt_kit/layer3_pkt_sender.rs
@@ -25,7 +25,7 @@ impl Layer3PacketSender {
 
     fn create_layer3_tcp_socket() -> TransportSender {
         let (tcp_sender, _) = transport_channel(4096, Layer3(IpNextHeaderProtocols::Tcp))
-            .expect("[ERROR] Could not create TCP transport channel");
+            .expect("[ ERROR ] Could not create TCP transport channel");
         
         tcp_sender
     }
@@ -34,7 +34,7 @@ impl Layer3PacketSender {
 
     fn create_layer3_udp_socket() -> TransportSender {
         let (udp_sender, _) = transport_channel(4096, Layer3(IpNextHeaderProtocols::Udp))
-            .expect("[ERROR] Could not create UDP transport channel");
+            .expect("[ ERROR ] Could not create UDP transport channel");
 
         udp_sender
     }

--- a/src/pkt_kit/mod.rs
+++ b/src/pkt_kit/mod.rs
@@ -7,8 +7,11 @@ pub use pkt_builder::PacketBuilder;
 pub mod pkt_dissector;
 pub use pkt_dissector::PacketDissector;
 
-pub mod pkt_sender;
-pub use pkt_sender::PacketSender;
+pub mod layer2_pkt_sender;
+pub use layer2_pkt_sender::Layer2PacketSender;
+
+pub mod layer3_pkt_sender;
+pub use layer3_pkt_sender::Layer3PacketSender;
 
 pub mod pkt_sniffer;
 pub use pkt_sniffer::PacketSniffer;

--- a/src/pkt_kit/pkt_builder.rs
+++ b/src/pkt_kit/pkt_builder.rs
@@ -9,7 +9,7 @@ use pnet::packet::{
     udp::{MutableUdpPacket, ipv4_checksum as udp_checksum},
 };
 use crate::pkt_kit::{HeaderBuffer, PacketBuffer};
-use crate::utils::{default_ipv4_addr};
+use crate::utils::{get_ipv4_addr};
 
 
 
@@ -23,11 +23,12 @@ pub struct PacketBuilder {
 
 impl PacketBuilder {
 
-    pub fn new() -> Self {
+    pub fn new(iface: String) -> Self {
+        let iface_ip = get_ipv4_addr(&iface);
         Self {
             headers: HeaderBuffer::default(),
             packets: PacketBuffer::default(),
-            src_ip:  default_ipv4_addr(),
+            src_ip:  iface_ip,
             rng:     rand::thread_rng(),
         }
     }

--- a/src/pkt_kit/pkt_sniffer.rs
+++ b/src/pkt_kit/pkt_sniffer.rs
@@ -60,8 +60,8 @@ impl PacketSniffer {
 
 
     fn create_sniffer(&self) -> Capture<pcap::Active> {
-        let dev     = PacketSniffer::get_default_iface();
-        let mut cap = PacketSniffer::open_capture(dev);
+        let dev     = self.get_default_iface();
+        let mut cap = PacketSniffer::open_capture(dev.clone());
         let filter  = self.get_bpf_filter_parameters();
         cap.filter(&filter, true).unwrap();
         
@@ -71,10 +71,12 @@ impl PacketSniffer {
 
 
 
-    fn get_default_iface() -> Device {
-        Device::lookup()
-            .expect("No default interface")
+    fn get_default_iface(&self) -> Device {
+        Device::list()
             .unwrap()
+            .into_iter()
+            .find(|d| d.name == self.iface)
+            .unwrap_or_else(|| panic!("Interface '{}' not found", self.iface))
     }
 
 

--- a/src/pkt_kit/pkt_sniffer.rs
+++ b/src/pkt_kit/pkt_sniffer.rs
@@ -4,13 +4,14 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 use pcap::{Device, Capture};
-use crate::utils::{default_ipv4_addr, default_iface_cidr};
+use crate::utils::{get_ipv4_addr, get_iface_cidr};
 
 
 
 pub struct PacketSniffer {
     command:     String,
     handle:      Option<thread::JoinHandle<()>>,
+    iface:       String,
     raw_packets: Arc<Mutex<Vec<Vec<u8>>>>,
     running:     Arc<AtomicBool>,
     src_ip:      String,
@@ -20,9 +21,10 @@ pub struct PacketSniffer {
 
 impl PacketSniffer {
 
-    pub fn new(command: String, target_ip: String) -> Self {
+    pub fn new(command: String, iface: String, target_ip: String) -> Self {
         Self {
             command,
+            iface,
             handle:      None,
             raw_packets: Arc::new(Mutex::new(Vec::new())),
             running:     Arc::new(AtomicBool::new(false)),
@@ -88,10 +90,10 @@ impl PacketSniffer {
 
 
     fn get_bpf_filter_parameters(&self) -> String {
-        let my_ip = default_ipv4_addr().to_string();
+        let my_ip = get_ipv4_addr(&self.iface);
 
         match self.command.as_str() {
-            "netmap"    => format!("tcp and dst host {} and src net {}", my_ip, default_iface_cidr()),
+            "netmap"    => format!("tcp and dst host {} and src net {}", my_ip, get_iface_cidr(&self.iface)),
             "pscan-tcp" => format!("tcp[13] & 0x12 == 0x12 and dst host {} and src host {}", my_ip, self.src_ip),
             "pscan-udp" => format!("icmp and icmp[0] == 3 and icmp[1] == 3 and dst host {} and src host {}", my_ip, self.src_ip),
             _           => panic!("[ ERROR ] Unknown filter: {}", self.command),

--- a/src/utils/delay_generator.rs
+++ b/src/utils/delay_generator.rs
@@ -6,18 +6,12 @@ pub struct DelayTimeGenerator;
 
 impl DelayTimeGenerator {
 
-    pub fn get_delay_list(delay_arg: Option<String>, quantity: usize) -> Vec<f32> {
-        if delay_arg.is_none() {
-            return Self::fixed_delay_range("0.04".to_string(), quantity)
+    pub fn get_delay_list(delay_arg: String, quantity: usize) -> Vec<f32> {
+        if delay_arg.contains("-") {
+            return Self::random_delay_range(delay_arg, quantity)
         }
 
-        let delay_str = delay_arg.unwrap();
-
-        if delay_str.contains("-") {
-            return Self::random_delay_range(delay_str, quantity)
-        }
-
-        Self::fixed_delay_range(delay_str, quantity)
+        Self::fixed_delay_range(delay_arg, quantity)
     }
 
 

--- a/src/utils/port_generator.rs
+++ b/src/utils/port_generator.rs
@@ -7,11 +7,8 @@ pub struct PortGenerator;
 
 impl PortGenerator {
 
-    pub fn get_ports(ports_str: Option<String>, random: bool) -> Vec<u16> {
-        let mut ports_vec: Vec<u16> = match ports_str {
-            Some(p) => Self::generate_specified_ports(p),
-            None    => (1..=100).collect(),
-        };
+    pub fn get_ports(ports_str: String, random: bool) -> Vec<u16> {
+        let mut ports_vec = Self::generate_ports(ports_str);
 
         if random {
             Self::shuffle_ports(&mut ports_vec);
@@ -22,7 +19,7 @@ impl PortGenerator {
 
 
 
-    fn generate_specified_ports(ports_str: String) -> Vec<u16> {
+    fn generate_ports(ports_str: String) -> Vec<u16> {
         let mut ports: BTreeSet<u16> = BTreeSet::new();
         let parts: Vec<&str>         = ports_str.split(",").collect();
         


### PR DESCRIPTION
Add `--iface` / `-i` flag to `flooder` and `mapper` to choose the network interface.

- Adds a CLI option `--iface` / `-i` to the `flooder` and `mapper commands to explicitly specify the network interface to use.
- When the flag is omitted, previous behavior is preserved (fall back to the system/default interface).
- The specified interface is validated at startup; if it does not exist the program exits with a clear error message.
- Updates the sniffer to open the chosen device directly instead of relying on `pcap::Device::lookup()`.