### PR TITLE
Add function to pick correct local source IPv4 for a destination

### DIFF
--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -45,7 +45,7 @@ impl PacketFlood {
 
 
     fn setup_tools(iface: String) -> (PacketBuilder, Layer2PacketSender) {
-        let pkt_builder = PacketBuilder::new(iface.clone());
+        let pkt_builder = PacketBuilder::new(iface.clone(), None);
         let pkt_sender  = Layer2PacketSender::new(iface.clone());
         (pkt_builder, pkt_sender)
     }

--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -44,7 +44,7 @@ impl NetworkMapper {
 
 
     fn setup_tools(&self) -> (PacketBuilder, Layer3PacketSender, PacketSniffer) {
-        let pkt_builder     = PacketBuilder::new(self.args.iface.clone());
+        let pkt_builder     = PacketBuilder::new(self.args.iface.clone(), None);
         let pkt_sender      = Layer3PacketSender::new();
         let mut pkt_sniffer = PacketSniffer::new("netmap".to_string(), self.args.iface.clone(), "".to_string());
 

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -1,7 +1,8 @@
 use std::{thread, time::Duration};
 use crate::arg_parser::PortScanArgs;
 use crate::pkt_kit::{PacketBuilder, PacketDissector, Layer3PacketSender, PacketSniffer};
-use crate::utils::{PortGenerator, inline_display, get_host_name, DelayTimeGenerator, default_iface_name};
+use crate::utils::{
+    PortGenerator, inline_display, get_host_name, DelayTimeGenerator, default_iface_name, source_ip_from_iface};
 
 
 
@@ -59,7 +60,8 @@ impl PortScanner {
 
     fn setup_tools(&self) -> (PacketBuilder, Layer3PacketSender, PacketSniffer) {
         let iface           = default_iface_name();
-        let pkt_builder     = PacketBuilder::new(iface.clone());
+        let src_ip          = source_ip_from_iface(self.args.target_ip.clone());
+        let pkt_builder     = PacketBuilder::new(iface.clone(), Some(src_ip));
         let pkt_sender      = Layer3PacketSender::new();
         let mut pkt_sniffer = PacketSniffer::new(self.filter(), iface.clone(), self.args.target_ip.to_string());
 

--- a/src/pkt_kit/pkt_builder.rs
+++ b/src/pkt_kit/pkt_builder.rs
@@ -23,12 +23,11 @@ pub struct PacketBuilder {
 
 impl PacketBuilder {
 
-    pub fn new(iface: String) -> Self {
-        let iface_ip = get_ipv4_addr(&iface);
+    pub fn new(iface: String, src_ip: Option<Ipv4Addr>) -> Self {
         Self {
             headers: HeaderBuffer::default(),
             packets: PacketBuffer::default(),
-            src_ip:  iface_ip,
+            src_ip:  src_ip.unwrap_or_else(|| get_ipv4_addr(&iface)),
             rng:     rand::thread_rng(),
         }
     }

--- a/src/utils/iface_info.rs
+++ b/src/utils/iface_info.rs
@@ -62,7 +62,7 @@ pub fn default_iface_mac(iface_name: &String) -> MacAddr {
 
 
 
-pub fn source_ip_for_dest(dst: Ipv4Addr) -> Ipv4Addr {
+pub fn source_ip_from_iface(dst: Ipv4Addr) -> Ipv4Addr {
     let sockaddr = SocketAddrV4::new(dst, 53);
     
     let sock = UdpSocket::bind(("0.0.0.0", 0))

--- a/src/utils/iface_info.rs
+++ b/src/utils/iface_info.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
 use ipnet::Ipv4Net;
 use netdev::interface::{get_default_interface, get_interfaces};
 use pnet::datalink::{self, MacAddr};
@@ -59,3 +59,22 @@ pub fn default_iface_mac(iface_name: &String) -> MacAddr {
     }
     abort(format!("[ERROR] Could not find the default interface with IP {}", my_ip));
 }
+
+
+
+pub fn source_ip_for_dest(dst: Ipv4Addr) -> Ipv4Addr {
+    let sockaddr = SocketAddrV4::new(dst, 53);
+    
+    let sock = UdpSocket::bind(("0.0.0.0", 0))
+        .unwrap_or_else(|e| abort(&format!("Failed to bind UDP socket: {}", e)));
+    
+    sock.connect(sockaddr)
+        .unwrap_or_else(|e| abort(&format!("Failed to connect UDP socket: {}", e)));
+
+    match sock.local_addr().unwrap().ip() {
+        std::net::IpAddr::V4(v4) => v4,
+        _ => abort("Expected a local IPv4 address, but got IPv6"),
+    }
+}
+
+


### PR DESCRIPTION
Implement `source_ip_from_iface(dst: Ipv4Addr) -> Ipv4Addr` using the UDP `connect()` + `local_addr()` trick so the kernel decides the proper local IP to use for reaching `dst`. This removes the need to guess an interface or hardcode the source address when building raw packets.

Why:
- Port scanner ran with the wrong source IP when multiple interfaces were present.
- Using the kernel-chosen local IP avoids mismatches like sending to 10.0.0.x with a 192.168.1.x source.
- Simpler and portable solution without enumerating interfaces or using rtnetlink.

Behavior:
- Returns the IPv4 address the kernel would use to reach `dst`.
- Aborts (via existing `abort()` helper) on error to match project error handling.