### PR TITLE
Bug fixed in the argument parsers

### DIFF
--- a/engines/beacon/arg_parser.go
+++ b/engines/beacon/arg_parser.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"offscan/conv"
 	"offscan/utils"
+	"os"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -30,11 +31,16 @@ type Args struct {
 func parseArgs(argList []string) *BcFloodArgs {
     var opts Args
 
-	parser := flags.NewParser(&opts, flags.None)
+	parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(argList)
 
 	if err != nil {
-        utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
+		if flags.WroteHelp(err) {
+			fmt.Printf("%v", err)
+			os.Exit(0)
+		}
+		
+		utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
     }
 
 	bcArgs := &BcFloodArgs{

--- a/engines/deauth/arg_parser.go
+++ b/engines/deauth/arg_parser.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"offscan/conv"
 	"offscan/utils"
+	"os"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -22,7 +23,7 @@ type DeauthArgs struct {
 
 type Args struct {
     Iface     string `short:"i" long:"iface" description:"Network interface" required:"true"`
-    TargetMac string `short:"t" long:"target-mac" description:"Target MAC" required:"true"`
+    TargetMac string `short:"t" long:"tmac" description:"Target MAC" required:"true"`
     Bssid     string `short:"b" long:"bssid" description:"BSSID" required:"true"`
     Delay     int    `short:"d" long:"delay" default:"30" description:"Delay in ms"`
     Channel   int    `short:"c" long:"channel" description:"Channel" required:"true"`
@@ -33,10 +34,15 @@ type Args struct {
 func ParseArgs(argList []string) *DeauthArgs {
     var opts Args
     
-    parser := flags.NewParser(&opts, flags.None)
+    parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(argList)
     
     if err != nil {
+        if flags.WroteHelp(err) {
+			fmt.Printf("%v", err)
+			os.Exit(0)
+		}
+        
         utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
     }
 

--- a/engines/floodping/arg_parser.go
+++ b/engines/floodping/arg_parser.go
@@ -3,6 +3,7 @@ package floodping
 import (
 	"fmt"
 	"offscan/utils"
+	"os"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -21,10 +22,15 @@ type PingArgs struct {
 func ParsePingArgs(args []string) *PingArgs {
     var opts PingArgs
     
-	parser := flags.NewParser(&opts, flags.None)
+	parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(args)
     
 	if err != nil {
+        if flags.WroteHelp(err) {
+			fmt.Printf("%v", err)
+			os.Exit(0)
+		}
+        
         utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
     }
     

--- a/engines/floodtcp/arg_parser.go
+++ b/engines/floodtcp/arg_parser.go
@@ -3,6 +3,7 @@ package floodtcp
 import (
 	"fmt"
 	"offscan/utils"
+	"os"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -22,10 +23,15 @@ type TcpArgs struct {
 func ParseTcpArgs(args []string) *TcpArgs {
     var opts TcpArgs
 
-	parser := flags.NewParser(&opts, flags.None)
+	parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(args)
 
 	if err != nil {
+        if flags.WroteHelp(err) {
+			fmt.Printf("%v", err)
+			os.Exit(0)
+		}
+        
         utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
     }
     

--- a/engines/netinfo/arg_parser.go
+++ b/engines/netinfo/arg_parser.go
@@ -3,6 +3,7 @@ package netinfo
 import (
 	"fmt"
 	"offscan/utils"
+	"os"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -18,10 +19,15 @@ type NetInfoArgs struct {
 func ParseNetInfoArgs(argList []string) *NetInfoArgs {
     var opts NetInfoArgs
 
-	parser := flags.NewParser(&opts, flags.None)
+	parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(argList)
 
 	if err != nil {
+		if flags.WroteHelp(err) {
+			fmt.Printf("%v", err)
+			os.Exit(0)
+		}
+		
         utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
     }
 

--- a/engines/netmap/arg_parser.go
+++ b/engines/netmap/arg_parser.go
@@ -3,6 +3,7 @@ package netmap
 import (
 	"fmt"
 	"offscan/utils"
+	"os"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -23,10 +24,15 @@ type NetMapArgs struct {
 func ParseNetMapArgs(args []string) *NetMapArgs {
     var opts NetMapArgs
     
-	parser := flags.NewParser(&opts, flags.None)
+	parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(args)
     
 	if err != nil {
+        if flags.WroteHelp(err) {
+			fmt.Printf("%v", err)
+			os.Exit(0)
+		}
+        
         utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
     }
     

--- a/engines/portscan/arg_parser.go
+++ b/engines/portscan/arg_parser.go
@@ -3,6 +3,7 @@ package portscan
 import (
 	"fmt"
 	"offscan/utils"
+	"os"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -22,10 +23,15 @@ type PortScanArgs struct {
 func ParsePortScanArgs(args []string) *PortScanArgs {
     var opts PortScanArgs
 
-	parser := flags.NewParser(&opts, flags.None)
+	parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(args)
 
 	if err != nil {
+        if flags.WroteHelp(err) {
+			fmt.Printf("%v", err)
+			os.Exit(0)
+		}
+        
         utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
     }
 

--- a/engines/wifimap/arg_parser.go
+++ b/engines/wifimap/arg_parser.go
@@ -3,6 +3,7 @@ package wifimap
 import (
 	"fmt"
 	"offscan/utils"
+	"os"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -17,10 +18,15 @@ type WmapArgs struct {
 func ParseWmapArgs(args []string) *WmapArgs {
     var opts WmapArgs
     
-	parser := flags.NewParser(&opts, flags.None)
+	parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(args)
     
 	if err != nil {
+		if flags.WroteHelp(err) {
+			fmt.Printf("%v", err)
+			os.Exit(0)
+		}
+		
         utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
     }
     


### PR DESCRIPTION
The parsers were not showing the flags when the helper was called (-h/--help). It happened because one of the flags used in the parser creation prevented the helper to be called. It was fixed and an Exit(0) was added.