### PR TITLE
Fix BPF filter for cross‑platform Wi‑Fi monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ## Dependencies
 
 This project uses **Go modules** to manage its dependencies.  
-If you don't have Go installed, follow the instructions on the [official Go website](https://go.dev/dl/).
+If you don't have Go installed, follow the instructions on the [official Go website](https://go.dev/dl/) to install the **latest version**.
 
 All Go dependencies are managed automatically via the `go.mod` file – no manual installation required.  
 You can find them listed in the [`go.mod`](https://github.com/olivercalazans/offscan/blob/main/go.mod) file.

--- a/engines/portscan/portscan.go
+++ b/engines/portscan/portscan.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"maps"
 	"net"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"offscan/internal/packet/builder"
 	"offscan/internal/packet/dissector"
 	"offscan/internal/sniffer"
+	"offscan/internal/utils"
 
 	"offscan/internal/sockets"
 	"offscan/internal/sysinfo"
@@ -210,9 +210,8 @@ func (ps *portScanner) formatPorts() {
         fmt.Println("None")
         return
     }
-
-    iter       := maps.Keys(ps.openPorts)
-    portsSlice := slices.Sorted(iter)
+    
+    portsSlice := utils.SortKeys(ps.openPorts)
 
     portsStr := make([]string, len(portsSlice))
     for i, p := range portsSlice {

--- a/engines/wifimap/wifimap.go
+++ b/engines/wifimap/wifimap.go
@@ -95,7 +95,7 @@ func (wm *wifiMapper) startBeaconProcessor() {
 
 
 func getBPFFilter() string {
-    return "ether[36] == 0x80"
+    return "wlan type mgt subtype beacon"
 }
 
 

--- a/engines/wifimap/wifimap.go
+++ b/engines/wifimap/wifimap.go
@@ -25,7 +25,7 @@ import (
 	"offscan/internal/frame80211/dissector"
 	"offscan/internal/ifconfig"
 	"offscan/internal/sniffer"
-	"sort"
+	"offscan/internal/utils"
 	"strings"
 	"sync"
 	"time"
@@ -234,20 +234,10 @@ func (wm *wifiMapper) displayResults() {
         }
     }
 
-    wifis    := wm.wInfo
-    wm.wInfo  = make(map[string]wifiData)
-
     wm.displayHeader(maxLen)
 
-    ssids := make([]string, 0, len(wifis))
-    for ssid := range wifis {
-        ssids = append(ssids, ssid)
-    }
-    sort.Strings(ssids)
-
-    for _, ssid := range ssids {
-        info := wifis[ssid]
-        wm.displayWifiInfo(ssid, &info, maxLen)
+    for _, ssid := range utils.SortKeys(wm.wInfo) {
+        wm.displayWifiInfo(ssid, maxLen)
     }
 }
 
@@ -271,20 +261,20 @@ func (wm *wifiMapper) displayHeader(maxLen int) {
 
 
 
-func (wm *wifiMapper) displayWifiInfo(ssid string, info *wifiData, maxLen int) {
-    bssidStrs := make([]string, 0, len(info.BSSIDs))
-    for bssid := range info.BSSIDs {
-        bssidStrs = append(bssidStrs, bssid)
-    }
-    sort.Strings(bssidStrs)
+func (wm *wifiMapper) displayWifiInfo(ssid string, maxLen int) {
+    info := wm.wInfo[ssid]
+
+    bssidStrs := utils.SortKeys(info.BSSIDs)
 
     firstBSSID := "N/A"
     if len(bssidStrs) > 0 {
         firstBSSID = bssidStrs[0]
     }
 
-    line := fmt.Sprintf("%-*s  %-4s  %-17s  %-3d  %-8s  %-4s\n",
-        maxLen, ssid, info.Freq, firstBSSID, info.Channel, info.Std, info.Sec)
+    line := fmt.Sprintf(
+        "%-*s  %-4s  %-17s  %-3d  %-8s  %-4s\n",
+        maxLen, ssid, info.Freq, firstBSSID, info.Channel, info.Std, info.Sec,
+    )
     
     fmt.Print(line)
 

--- a/internal/sniffer/bpf_comp.go
+++ b/internal/sniffer/bpf_comp.go
@@ -12,7 +12,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://gnu.org>.
+ * along with this program.  If not, see <https://www.gnu.org>.
  */
 
 package sniffer
@@ -36,6 +36,8 @@ import "C"
 
 import (
 	"fmt"
+	"offscan/internal/sysinfo"
+	"offscan/internal/utils"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -43,21 +45,26 @@ import (
 
 
 func (s *Sniffer) compileFilter() ([]unix.SockFilter, error) {
-	cFilterText := C.CString(s.filter)
-	defer C.free(unsafe.Pointer(cFilterText))
+    cFilterText := C.CString(s.filter)
+    defer C.free(unsafe.Pointer(cFilterText))
 
-	var bpfProg C.struct_bpf_program
+    var bpfProg C.struct_bpf_program
 
-	if res := C.compile_bpf_filter(1, cFilterText, &bpfProg); res < 0 {
-		return nil, fmt.Errorf("invalid BPF filter syntax")
+	linkType, err := sysinfo.GetIfaceLinkType(s.iface)
+
+	if err != nil {
+		utils.Abort(fmt.Sprintf("%v", err))
 	}
-	defer C.pcap_freecode(&bpfProg)
 
-	numInstructions := int(bpfProg.bf_len)
-	cInstructions   := unsafe.Slice((*unix.SockFilter)(unsafe.Pointer(bpfProg.bf_insns)), numInstructions)
+    if res := C.compile_bpf_filter(C.int(linkType), cFilterText, &bpfProg); res < 0 {
+        return nil, fmt.Errorf("Invalid BPF filter syntax")
+    }
+    defer C.pcap_freecode(&bpfProg)
 
-	goInstructions := make([]unix.SockFilter, numInstructions)
+    numInstructions := int(bpfProg.bf_len)
+    cInstructions   := unsafe.Slice((*unix.SockFilter)(unsafe.Pointer(bpfProg.bf_insns)), numInstructions)
+    goInstructions  := make([]unix.SockFilter, numInstructions)
+    
 	copy(goInstructions, cInstructions)
-
-	return goInstructions, nil
+    return goInstructions, nil
 }

--- a/internal/sysinfo/iface_linktype.go
+++ b/internal/sysinfo/iface_linktype.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 Oliver R. Calazans Jeronimo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org>.
+ */
+
+package sysinfo
+
+import (
+	"fmt"
+	"net"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+
+func GetIfaceLinkType(iface *net.Interface) (int, error) {
+    fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, 0)
+
+	if err != nil {
+        return 0, err
+    }
+    defer unix.Close(fd)
+
+    var ifreq struct {
+        name [16]byte
+        data [32]byte
+    }
+
+	copy(ifreq.name[:], []byte(iface.Name))
+
+    _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), unix.SIOCGIFHWADDR, uintptr(unsafe.Pointer(&ifreq)))
+    
+	if errno != 0 {
+        return 0, errno
+    }
+
+    arpType := int(ifreq.data[0]) | (int(ifreq.data[1]) << 8)
+
+    switch arpType {
+    case unix.ARPHRD_ETHER:  // 1
+        return 1, nil        // DLT_EN10MB    
+	case unix.ARPHRD_IEEE80211:  // 801
+        return 105, nil 		 // DLT_IEEE802_11
+	case unix.ARPHRD_IEEE80211_RADIOTAP:  // 803
+        return 127, nil 				  // DLT_IEEE802_11_RADIO
+    default:
+        return 0, fmt.Errorf("unsupported ARPHRD type %d", arpType)
+    }
+}

--- a/internal/utils/sort_keys.go
+++ b/internal/utils/sort_keys.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 Oliver R. Calazans Jeronimo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org>.
+ */
+
+package utils
+
+import (
+	"cmp"
+	"maps"
+	"slices"
+)
+
+
+func SortKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	iter  := maps.Keys(m)
+    slice := slices.Sorted(iter)
+    return slice
+}


### PR DESCRIPTION
`ether[36] == 0x80` assumes a fixed frame layout, but Linux monitor mode may add a radiotap header of variable size. Works on some machines (where offset 36 lands on the beacon byte) but fails on others.

### Solution
- Detect interface ARPHRD type via `ioctl` and map to correct `DLT_*` for `pcap_compile`.
- Replace hardcoded offset with semantic filter: `wlan type mgt subtype beacon`.

Sniffer now works universally across any Wi‑Fi driver/kernel (radiotap or pure 802.11) without recompilation.