### PR TITLE
Live Layer 2 Wi-Fi Discovery with Real‑Time Output

### DIFF
--- a/engines/l2disc/l2disc.go
+++ b/engines/l2disc/l2disc.go
@@ -18,15 +18,18 @@
 package l2disc
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"math"
 	"net"
-	"offscan/internal/conv"
-	"offscan/internal/frame80211/dissector"
 	"offscan/internal/ifconfig"
 	"offscan/internal/sniffer"
+	"os"
+	"os/signal"
+	"slices"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -41,12 +44,12 @@ func Run(args []string) {
 type layer2HostDiscovery struct{
 	iface       net.Interface
 	sniffTime   time.Duration
-	retrys      int
-	nets        map[beaconInfo]struct{}
-	stations    map[dataFrameInfo]struct{}
 	sniffer    *sniffer.Sniffer
-	mut         sync.Mutex
 	wg          sync.WaitGroup
+	eventCh     chan dot11Info
+	ctx         context.Context
+	cancel      context.CancelFunc
+	errChnls    map[int]struct{}
 }
 
 
@@ -58,9 +61,7 @@ func newL2Disc(args []string) *layer2HostDiscovery {
 	return &layer2HostDiscovery{
 		iface     : parser.Iface,
 		sniffTime : calculateDuration(parser.sniffTime),
-		retrys    : parser.retrys,
-		nets      : make(map[beaconInfo]struct{}),
-	    stations  : make(map[dataFrameInfo]struct{}),
+		errChnls  : make(map[int]struct{}),
 	}
 }
 
@@ -75,33 +76,51 @@ func calculateDuration(sniffTime float64) time.Duration {
 
 func (l2hd *layer2HostDiscovery) execute() {
 	l2hd.displayExecInfo()
+	l2hd.createCtx()
 	l2hd.startFrameProcessor()
-	l2hd.sniffChannels()
+	l2hd.sniffEndlessly()
 	l2hd.stopFrameProcessor()
-	l2hd.displayResults()
 }
 
 
 
 func (l2hd *layer2HostDiscovery) displayExecInfo() {
 	fmt.Printf("[*] IFACE: %s\n", l2hd.iface.Name)
-	fmt.Printf("[*] TIME.: %.2fs\n", l2hd.sniffTime.Seconds())
-	fmt.Printf("[*] RETRY: %d\n", l2hd.retrys)
+	fmt.Printf("[*] DELAY: %.2fs\n", l2hd.sniffTime.Seconds())
+}
+
+
+
+func (l2hd *layer2HostDiscovery) createCtx() {
+    l2hd.ctx, l2hd.cancel = context.WithCancel(context.Background())
+
+	go func() {
+        sigCh := make(chan os.Signal, 1)
+        signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+        <-sigCh
+        fmt.Println("\n[!] Interrupt received. Stopping...")
+        l2hd.cancel()
+    }()
 }
 
 
 
 func (l2hd *layer2HostDiscovery) startFrameProcessor() {
+	l2hd.eventCh = make(chan dot11Info, 1024)
+    go l2hd.displayLoop()
+
 	l2hd.sniffer  = sniffer.NewSniffer(l2hd.iface, getBPFFilter(), true)
 	sniffCh      := l2hd.sniffer.Start()
 
-	fmt.Printf("[+] Sniffing 802.11 frames\n")
+	fmt.Printf("[+] Sniffing 802.11 frames. Press CTRL + C to stop\n")
 
 	l2hd.wg.Add(1)
 	go func() {
 		defer l2hd.wg.Done()
 		l2hd.processFrame(sniffCh)
 	}()
+
+	displayHeader()
 }
 
 
@@ -112,142 +131,69 @@ func getBPFFilter() string {
 
 
 
-func (l2hd *layer2HostDiscovery) processFrame(sniffCh <-chan []byte) {
-	tools := dissecAndBufs{
-		staBuf    : make(map[dataFrameInfo]struct{}),
-		netsBuf   : make(map[beaconInfo]struct{}),
-		dissector : dissector.NewDot11Dissector(),
-	}
+func (l2hd *layer2HostDiscovery) sniffEndlessly() {
+    for {
+        select {
+        case <-l2hd.ctx.Done():
+            return
 
-	for {
-		frame, ok := <-sniffCh
-		if !ok { break }
-		tools.dissector.UpdatePkt(frame)
-		l2hd.updateInfo(&tools)
-	}
+		default:
+        }
 
-	l2hd.mut.Lock()
-	maps.Copy(l2hd.stations, tools.staBuf)
-	maps.Copy(l2hd.nets, tools.netsBuf)
-	l2hd.mut.Unlock()
-}
+        l2hd.sniff2GChannels()
+        l2hd.sniff5GChannels()
 
-
-
-func (l2hd *layer2HostDiscovery) updateInfo(tools *dissecAndBufs) {
-	if tools.dissector.IsBeacon {
-		ap := beaconInfo{
-			ssid  : tools.dissector.GetSSID(),
-			bssid : tools.dissector.GetBSSID(),
-			chnl  : tools.dissector.GetChannel(),
-		}
-
-		tools.netsBuf[ap] = struct{}{}
-	}
-
-	if tools.dissector.IsDataFrm {
-		bssid, staMac, ok := tools.dissector.GetAddrs()
-		if !ok { return }
-		sta := dataFrameInfo{ bssid: bssid, staMac: staMac }
-		tools.staBuf[sta] = struct{}{}
-	}
-}
-
-
-
-func (l2hd *layer2HostDiscovery) sniffChannels() {
-	for i := range l2hd.retrys {
-		fmt.Printf("[#] %d° try\n", i + 1)
-		l2hd.sniff2GChannels()
-		l2hd.sniff5GChannels()
-	}
+		if l2hd.ctx.Err() != nil { return }
+    }
 }
 
 
 
 func (l2hd *layer2HostDiscovery) sniff2GChannels() {
 	channels := ifconfig.Channels2()
-	l2hd.sniff(channels, "2.4")
+	l2hd.sniff(channels)
 }
 
 
 
 func (l2hd *layer2HostDiscovery) sniff5GChannels() {
 	channels := ifconfig.Channels5()
-	l2hd.sniff(channels, "5")
+	l2hd.sniff(channels)
 }
 
 
 
-func (l2hd *layer2HostDiscovery) sniff(channels []int, freq string) {
-	var errChannels []int
-
-	for _, chnl := range channels {
+func (l2hd *layer2HostDiscovery) sniff(channels []int) {
+    for _, chnl := range channels {
+        if l2hd.ctx.Err() != nil { return }
+        
 		ok := ifconfig.TrySetChannel(l2hd.iface, chnl)
+        if ok != nil {
+            l2hd.errChnls[chnl] = struct{}{}
+            continue
+        }
 
-		if ok != nil {
-			errChannels = append(errChannels, chnl)
-			continue
-		}
-
-		time.Sleep(l2hd.sniffTime)
-	}
-
-	if len(errChannels) > 0 {
-		fmt.Printf("[!] Unable to sniff these channels (%sG):\n%v\n", freq, errChannels)
-	}
+		select {
+        case <-time.After(l2hd.sniffTime):
+        case <-l2hd.ctx.Done(): return }
+    }
 }
 
 
 
 func (l2hd *layer2HostDiscovery) stopFrameProcessor() {
 	l2hd.sniffer.Stop()
-	fmt.Println("[-] Sniffer stopped")
+	close(l2hd.eventCh)
+	
+	fmt.Println("[-] Process stopped")
+	l2hd.displayErrChannels()
 	l2hd.wg.Wait()
 }
 
 
 
-func (l2hd *layer2HostDiscovery) displayResults() {
-	nets, maxLen := l2hd.extractKeysAndMaxLen()
-
-	for _, net := range nets {
-		l2hd.displayStation(&net, maxLen)
-	}
-}
-
-
-
-func (l2hd *layer2HostDiscovery) extractKeysAndMaxLen() ([]beaconInfo, int) {
-	maxLen := 4
-	keys   := make([]beaconInfo, 0, len(l2hd.nets))
-	
-	for netData := range l2hd.nets {
-		keys = append(keys, netData)
-
-        if len(netData.ssid) > maxLen {
-			maxLen = len(netData.ssid)
-		}
-	}
-
-    return keys, maxLen
-}
-
-
-
-func (l2hd *layer2HostDiscovery) displayStation(net *beaconInfo, maxLen int) {
-	for sta := range l2hd.stations {
-		if sta.bssid != net.bssid {	continue }
-
-		
-		fmt.Printf(
-			"%-*s  %-3d  %s  %s\n", 
-			maxLen, net.ssid, net.chnl,
-			conv.Byte6ToStr(net.bssid), 
-			conv.Byte6ToStr(sta.staMac),
-		)
-		
-		delete(l2hd.stations, sta)
-		return
-	}
+func (l2hd *layer2HostDiscovery) displayErrChannels() {
+	if len(l2hd.errChnls) == 0 { return }
+	chnls := slices.Collect(maps.Keys(l2hd.errChnls))
+	fmt.Printf("[!] Unable to sniff these channels: %v\n", chnls)
 }

--- a/engines/l2disc/l2disc_frm_proc.go
+++ b/engines/l2disc/l2disc_frm_proc.go
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2025 Oliver R. Calazans Jeronimo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org>.
+ */
+
+package l2disc
+
+import (
+	"fmt"
+	"offscan/internal/conv"
+	"offscan/internal/frame80211/dissector"
+	"strings"
+)
+
+
+func (l2hd *layer2HostDiscovery) processFrame(sniffCh <-chan []byte) {
+	dissector := dissector.NewDot11Dissector()
+
+	for {
+		frame, ok := <-sniffCh
+		if !ok { break }
+		dissector.UpdatePkt(frame)
+		l2hd.sendToUpdate(dissector)
+	}
+}
+
+
+
+func (l2hd *layer2HostDiscovery) sendToUpdate(dissector *dissector.Dot11Dissector) {
+	info := dot11Info{}
+
+	if dissector.IsBeacon {
+		info.isBeacon = true
+		info.bssid    = dissector.GetBSSID()
+		info.chnl     = dissector.GetChannel()
+		info.ssid     = dissector.GetSSID()
+		
+		select {
+        case l2hd.eventCh <- info:
+        default:
+        }
+        return
+	}
+
+	if dissector.IsDataFrm {
+		bssid, staMac, ok := dissector.GetAddrs()
+		if !ok { return }
+		
+		info.isDataFrm = true
+		info.bssid     = bssid
+		info.staMac    = staMac
+
+		select {
+        case l2hd.eventCh <- info:
+        default:
+        }
+	}
+}
+
+
+
+func (l2hd *layer2HostDiscovery) displayLoop() {
+	bufs := buffers{
+		nets : make(map[[6]byte]beacon),
+		stas : make(map[station]struct{}),
+		miss : make(map[station]struct{}),
+	}
+
+	for data := range l2hd.eventCh {
+		if data.isBeacon {
+			netInfo := beacon{ ssid: data.ssid, chnl: data.chnl }
+			bufs.nets[data.bssid] = netInfo
+			associateStas(&bufs, data.bssid)
+		}
+
+		if data.isDataFrm {
+			staInfo := station{ bssid: data.bssid, staMac: data.staMac }
+			addStation(&bufs, staInfo)
+		}
+	}
+}
+
+
+
+func associateStas(bufs *buffers, bssid [6]byte) {
+	for sta := range bufs.miss {
+        if sta.bssid == bssid {
+        	delete(bufs.miss, sta)
+            addStation(bufs, sta)
+        }
+    }
+}
+
+
+
+func addStation(bufs *buffers, staInfo station) {
+    net, ok := bufs.nets[staInfo.bssid]
+
+    if !ok {
+        bufs.miss[staInfo] = struct{}{}
+        return
+    }
+
+    if _, exists := bufs.stas[staInfo]; exists {
+        return
+    }
+    
+	bufs.stas[staInfo] = struct{}{}
+    displayStation(&net, &staInfo)
+}
+
+
+
+func displayHeader() {
+	fmt.Printf(
+        "\n%-17s  %-17s  %-3s  %s\n",
+		"STA MAC", "BSSID", "Ch", "SSID",
+	)
+
+	fmt.Printf(
+		"%s  %s  %s  %s\n",
+		strings.Repeat("-", 17),
+		strings.Repeat("-", 17),
+		strings.Repeat("-", 3),
+		strings.Repeat("-", 4),
+	)
+}
+
+
+
+func displayStation(net *beacon, sta *station) {
+	fmt.Printf(
+		"%s  %s  %-3d  %s\n",
+		conv.Byte6ToStr(sta.staMac),
+		conv.Byte6ToStr(sta.bssid), 
+		net.chnl,
+		net.ssid,
+	)
+}

--- a/engines/l2disc/l2disc_parser.go
+++ b/engines/l2disc/l2disc_parser.go
@@ -61,10 +61,6 @@ func FlagSettings() []argparser.Flag {
 			ID: sniffTime, Short: "t", Long: "time", HasValue: true, 
 			Desc: "Time in seconds to sniff each channel (Default 1)",
 		},
-		{
-			ID: retrys, Short: "r", Long: "retry", HasValue: true,
-			Desc: "Retrys",
-		},
 	}
 }
 
@@ -79,7 +75,6 @@ func (l2dp *l2DiscParser) parseL2DiscArgs(args []string) {
 		switch flag.ID {
 		case iface     : l2dp.Iface     = conv.MustStrToIface(flag.ValueStr)
 		case sniffTime : l2dp.sniffTime = parseFloat(flag.ValueStr)
-		case retrys    : l2dp.retrys    = parseInt(flag.ValueStr)
 		}
 	}
 }
@@ -97,20 +92,6 @@ func parseFloat(str string) float64 {
 
 	if value <= 0 {
 		utils.Abort(fmt.Sprintf("Sniffing time can't be negative: %v", err))
-	}
-
-	return value
-}
-
-
-
-func parseInt(str string) int {
-	if str == "" { return 1 }
-
-	value := conv.MustStrToInt(str)
-
-	if value <= 0 {
-		utils.Abort(fmt.Sprintf("Retrys can't be negative: %d", value))
 	}
 
 	return value

--- a/engines/l2disc/l2disc_structs.go
+++ b/engines/l2disc/l2disc_structs.go
@@ -17,24 +17,31 @@
 
 package l2disc
 
-import "offscan/internal/frame80211/dissector"
+
+type dot11Info struct {
+	isBeacon   bool
+	bssid      [6]byte
+	ssid       string
+	chnl       uint8
+	isDataFrm  bool
+	staMac     [6]byte
+}
 
 
-type dataFrameInfo struct {
+type buffers struct {
+	nets  map[[6]byte]beacon
+	stas  map[station]struct{}
+	miss  map[station]struct{}
+}
+
+
+type beacon struct {
+	ssid  string
+	chnl  uint8
+}
+
+
+type station struct {
 	bssid   [6]byte
 	staMac  [6]byte
-}
-
-
-type beaconInfo struct {
-	bssid  [6]byte
-	ssid   string
-	chnl   uint8
-}
-
-
-type dissecAndBufs struct {
-	dissector  *dissector.Dot11Dissector
-	staBuf      map[dataFrameInfo]struct{}
-	netsBuf     map[beaconInfo]struct{}
 }


### PR DESCRIPTION
This PR overhauls the `l2disc` module to operate in continuous, real‑time mode. Previously, the tool captured frames for a fixed duration, processed everything offline, and only then printed the results. Now it runs indefinitely, discovers devices as they appear, and displays them immediately – all while hopping through 2.4 GHz and 5 GHz channels.

## Changes
- **Removed the batch‑style `retrys` loop** – the tool now runs until interrupted by the user (Ctrl+C).
- **Real‑time display** – stations are printed the moment they are associated with a known BSSID (once the corresponding beacon has been seen).
- **Graceful shutdown** – a `context.Context` combined with `signal.Notify` catches `SIGINT/SIGTERM`, cancels ongoing operations, stops the sniffer, closes the event channel, and waits for all goroutines to finish cleanly.
- **Channel‑based communication** – beacon and data frame events are sent over a buffered channel (`eventCh`) to a dedicated `displayLoop` goroutine. This goroutine owns all display state (networks, already‑printed stations, pending stations) and uses no mutexes – purely Go's "share memory by communicating" model.
- **Cancelable channel sleeping** – `time.After` with `select` inside the `sniff()` loop allows immediate reaction to shutdown signals, even while waiting on a channel.