### PR TITLE
Fix ARP packet construction and IPv4 handling for host discovery.

### DIFF
--- a/engines/hostdisc/hd_pkt_send.go
+++ b/engines/hostdisc/hd_pkt_send.go
@@ -62,7 +62,7 @@ func (hd *hostDiscovery) sendProbes() {
         }
     }
 
-    hd.stopSocket(&tools.socket)
+    hd.stopSocket(&tools.l3sock)
     fmt.Printf("[!] Packets not sent: %d\n", pktErr)
     time.Sleep(2 * time.Second)
 }
@@ -70,11 +70,12 @@ func (hd *hostDiscovery) sendProbes() {
 
 
 func (hd *hostDiscovery) initTools(tools *probeTools) {
-    tools.socket = sockets.NewL3Socket(&hd.iface)
+    tools.l2sock = sockets.NewL2Socket(&hd.iface)
+    tools.l3sock = sockets.NewL3Socket(&hd.iface)
     
     if hd.protocols.arp {
         tools.arp = builder.NewArpPkt()
-        tools.arp.AddStaticAddrs(hd.iface.HardwareAddr, hd.myIP)
+        tools.arp.AddReqStaticAddrs(hd.iface.HardwareAddr, hd.myIP)
     }
 
     if hd.protocols.icmp {
@@ -91,8 +92,8 @@ func (hd *hostDiscovery) initTools(tools *probeTools) {
 
 
 func (hd *hostDiscovery) sendArpProbe(tools *probeTools) bool {
-    pkt := tools.arp.L3RequestPkt(tools.dstIP)
-    tools.socket.SendTo(pkt, tools.dstIP)
+    pkt := tools.arp.L3ReqPkt(tools.dstIP)
+    tools.l2sock.Send(pkt)
     time.Sleep(delay)
     return true
 }
@@ -101,7 +102,7 @@ func (hd *hostDiscovery) sendArpProbe(tools *probeTools) bool {
 
 func (hd *hostDiscovery) sendIcmpProbe(tools *probeTools) bool {
     pkt := tools.icmp.L3PingPkt(hd.myIP, tools.dstIP)    
-    tools.socket.SendTo(pkt, tools.dstIP)
+    tools.l3sock.SendTo(pkt, tools.dstIP)
     time.Sleep(delay)
     return true
 }
@@ -110,7 +111,7 @@ func (hd *hostDiscovery) sendIcmpProbe(tools *probeTools) bool {
 
 func (hd *hostDiscovery) sendTcpProbe(tools *probeTools, srcPort  uint16) bool {
     pkt := tools.tcp.L3SynPkt(hd.myIP, srcPort, tools.dstIP, 80)
-    tools.socket.SendTo(pkt, tools.dstIP)
+    tools.l3sock.SendTo(pkt, tools.dstIP)
     time.Sleep(delay)
     return true
 }

--- a/engines/hostdisc/hd_pkt_send.go
+++ b/engines/hostdisc/hd_pkt_send.go
@@ -62,7 +62,7 @@ func (hd *hostDiscovery) sendProbes() {
         }
     }
 
-    hd.stopSocket(&tools.l3sock)
+    hd.stopSockets(&tools)
     fmt.Printf("[!] Packets not sent: %d\n", pktErr)
     time.Sleep(2 * time.Second)
 }
@@ -118,8 +118,16 @@ func (hd *hostDiscovery) sendTcpProbe(tools *probeTools, srcPort  uint16) bool {
 
 
 
-func (hd *hostDiscovery) stopSocket(socket *sockets.Layer3Socket) {
-    if err := socket.Close(); err != nil {
-        fmt.Printf("[!] Error closing socket: %v\n", err)
+func (hd *hostDiscovery) stopSockets(tools *probeTools) {
+    if hd.protocols.arp {
+        if err := tools.l2sock.Close(); err != nil {
+            fmt.Printf("[!] Error closing layer 2 socket: %v\n", err)
+        }
+    }
+
+    if hd.protocols.icmp || hd.protocols.tcp {
+        if err := tools.l3sock.Close(); err != nil {
+            fmt.Printf("[!] Error closing layer 3 socket: %v\n", err)
+        }
     }
 }

--- a/internal/conv/netip_to_ipv4.go
+++ b/internal/conv/netip_to_ipv4.go
@@ -15,31 +15,21 @@
  * along with this program.  If not, see <https://www.gnu.org>.
  */
 
-package hostdisc
+package conv
 
 import (
+	"fmt"
 	"net"
-	"offscan/internal/packet/builder"
-	"offscan/internal/sockets"
+	"offscan/internal/utils"
 )
 
 
-type protocols struct {
-    arp, icmp, tcp bool
-}
+func MustTo4(ip net.IP) net.IP {
+	ipv4 := ip.To4()
 
+	if ipv4 == nil {
+		utils.Abort(fmt.Sprintf("Invalid addres for IPv4: %s", ip.String()))
+	}
 
-type hostInfo struct {
-    Mac  net.HardwareAddr
-    Name string
-}
-
-
-type probeTools struct {
-    l2sock  sockets.Layer2Socket
-    l3sock  sockets.Layer3Socket
-    arp     builder.ArpPacket
-    icmp    builder.IcmpPacket
-    tcp     builder.TcpPacket
-    dstIP   net.IP
+	return ipv4
 }

--- a/internal/packet/builder/arp_pkt.go
+++ b/internal/packet/builder/arp_pkt.go
@@ -19,17 +19,20 @@ package builder
 
 import (
 	"net"
+	"offscan/internal/conv"
 )
 
 
 type ArpPacket struct {
-	buffer [28]byte
+	buffer    [42]byte
+	arpHdr    [28]byte
+	etherHdr  etherHeader
 }
 
 
 
 func NewArpPkt() ArpPacket {
-	ap := ArpPacket{}
+	ap := ArpPacket{ etherHdr: newEtherHeader() }
 	ap.buildFixed()
 	return ap
 }
@@ -37,32 +40,54 @@ func NewArpPkt() ArpPacket {
 
 
 func (ap *ArpPacket) buildFixed() {
-	ap.buffer[0] = 0x00   // HTYPE = 1 (Ethernet) - big endian
-	ap.buffer[1] = 0x01
-	ap.buffer[2] = 0x08   // PTYPE = 0x0800 (IPv4) - big endian
-	ap.buffer[3] = 0x00
-	ap.buffer[4] = 0x06   // HLEN = 6
-	ap.buffer[5] = 0x04   // PLEN = 4
-	ap.buffer[6] = 0x00   // OPER = 1 (request) - big endian
-	ap.buffer[7] = 0x01
+	ap.etherHdr.setArpType()
+
+	ap.arpHdr[0] = 0x00   // HTYPE = 1 (Ethernet) - big endian
+	ap.arpHdr[1] = 0x01
+	ap.arpHdr[2] = 0x08   // PTYPE = 0x0800 (IPv4) - big endian
+	ap.arpHdr[3] = 0x00
+	ap.arpHdr[4] = 0x06   // HLEN = 6
+	ap.arpHdr[5] = 0x04   // PLEN = 4
+	ap.arpHdr[6] = 0x00   // OPER = 1 (request) - big endian
+	ap.arpHdr[7] = 0x01
 	// THA (6 bytes, 18:24) - zero 
 }
 
 
 
-func (ap *ArpPacket) AddStaticAddrs(
+func (ap *ArpPacket) AddReqStaticAddrs(
 	srcMac  net.HardwareAddr,
 	srcIP   net.IP,
 ) {
+	ap.etherHdr.setDstAddr(net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
+	ap.etherHdr.setSrcAddr(srcMac)
+	ap.copyEtherHdr()
+
 	// 0:8 - fixed
-	copy(ap.buffer[8:14], srcMac)
-	copy(ap.buffer[14:18], srcIP)
+	ipv4 := conv.MustTo4(srcIP)
+	copy(ap.arpHdr[8:14], srcMac)
+	copy(ap.arpHdr[14:18], ipv4)
 	// 18:24 - fixed
 }
 
 
 
-func (ap *ArpPacket) L3RequestPkt(dstIP net.IP) []byte {
-	copy(ap.buffer[24:28], dstIP)
+func (ap *ArpPacket) copyEtherHdr() {
+	copy(ap.buffer[:14], ap.etherHdr.header[:])
+}
+
+
+
+func (ap *ArpPacket) copyArpHdr() {
+	copy(ap.buffer[14:], ap.arpHdr[:])
+}
+
+
+
+func (ap *ArpPacket) L3ReqPkt(dstIP net.IP) []byte {
+	ipv4 := conv.MustTo4(dstIP)
+	copy(ap.arpHdr[24:28], ipv4)
+	ap.copyArpHdr()
+	
 	return ap.buffer[:]
 }

--- a/internal/packet/builder/ether_hdr.go
+++ b/internal/packet/builder/ether_hdr.go
@@ -15,31 +15,38 @@
  * along with this program.  If not, see <https://www.gnu.org>.
  */
 
-package hostdisc
+package builder
 
 import (
+	"encoding/binary"
 	"net"
-	"offscan/internal/packet/builder"
-	"offscan/internal/sockets"
 )
 
 
-type protocols struct {
-    arp, icmp, tcp bool
+type etherHeader struct {
+	header  [14]byte
 }
 
 
-type hostInfo struct {
-    Mac  net.HardwareAddr
-    Name string
+
+func newEtherHeader() etherHeader {
+	return etherHeader{}
 }
 
 
-type probeTools struct {
-    l2sock  sockets.Layer2Socket
-    l3sock  sockets.Layer3Socket
-    arp     builder.ArpPacket
-    icmp    builder.IcmpPacket
-    tcp     builder.TcpPacket
-    dstIP   net.IP
+
+func (eh *etherHeader) setArpType() {
+	binary.BigEndian.PutUint16(eh.header[12:14], 0x806)
+}
+
+
+
+func (eh *etherHeader) setDstAddr(dstMAC net.HardwareAddr) {
+	copy(eh.header[0:6], dstMAC)
+}
+
+
+
+func (eh *etherHeader) setSrcAddr(srcMAC net.HardwareAddr) {
+	copy(eh.header[6:12], srcMAC)
 }

--- a/internal/packet/builder/ip_hdr.go
+++ b/internal/packet/builder/ip_hdr.go
@@ -20,6 +20,7 @@ package builder
 import (
 	"encoding/binary"
 	"net"
+	"offscan/internal/conv"
 )
 
 
@@ -66,20 +67,14 @@ func (iph *ipHeader) calculateChecksum() {
 
 
 
-func (iph *ipHeader) setSrcIp(srcIp net.IP) {
-	src := srcIp.To4()
-	
-	if src == nil{ return }
-
-	copy(iph.header[12:16], src)
+func (iph *ipHeader) setSrcIp(srcIP net.IP) {
+	ipv4 := conv.MustTo4(srcIP)
+	copy(iph.header[12:16], ipv4)
 }
 
 
 
-func (iph *ipHeader) setDstIp(dstIp net.IP) {
-	dst := dstIp.To4()
-
-	if dst == nil { return }
-
-	copy(iph.header[16:20], dst)
+func (iph *ipHeader) setDstIp(dstIP net.IP) {
+	ipv4 := conv.MustTo4(dstIP)
+	copy(iph.header[16:20], ipv4)
 }


### PR DESCRIPTION
## Changes
- Switched from L3 socket (AF_INET/SOCK_RAW) to L2 socket (AF_PACKET) – ARP now uses the correct raw socket for Ethernet frames.
- Added Ethernet header builder (ether_hdr.go) – we now build the full 14‑byte Ethernet header (destination MAC, source MAC, EtherType) instead of relying on the kernel.
- Fixed IPv4 conversion – always call ip.To4() before copying IP addresses into the packets. This ensures the correct 4‑byte binary representation (no more ASCII or 16‑byte IPv6‑mapped addresses).
- ARP packet builder (arp_pkt.go) now assembles the complete 42‑byte frame (Ethernet + ARP).

## Result
- ARP discovery works reliably. Wireshark shows correct Ethernet headers, sender/target IP addresses, and we receive replies from the network.
