### PR TITLE
Fix bug in pkt dissector

### DIFF
--- a/internal/packet/dissec_pkt.go
+++ b/internal/packet/dissec_pkt.go
@@ -42,7 +42,7 @@ func (pd *PacketDissector) UpdatePkt(rawPkt []byte) {
     pd.pkt    = rawPkt
 
     pd.flushArpVars()
-    pd.checkArpOpcode()	
+    pd.checkProtocol()	
 }
 
 


### PR DESCRIPTION
This PR fixes a bug in `PacketDissector` which prevented the IPv4 verification.